### PR TITLE
ERC1155 Soulbound Token

### DIFF
--- a/src/contracts/sbt-ERC1155/interfaces/ISBT.cairo
+++ b/src/contracts/sbt-ERC1155/interfaces/ISBT.cairo
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace ISBT {
+
+    // ERC165
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+
+    func uri(id: Uint256) -> (uri: felt) {
+    }
+
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(
+        accounts_len: felt,
+        accounts: felt*,
+        ids_len: felt,
+        ids: Uint256*
+    ) -> (
+        balances_len: felt,
+        balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+    }
+
+    func owner() -> (owner: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt,
+        to: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    func mint(
+        to: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) {
+    }
+
+    func mintBatch(
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    func burn(
+        from_:felt,
+        id: Uint256,
+        value: Uint256,
+    ) {
+    }
+
+    func transferOwnership(newOwner: felt) {
+    }
+
+    func renounceOwnership() {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.codecov.yml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.codecov.yml
@@ -1,0 +1,11 @@
+comment: off
+github_checks:
+  annotations: false
+coverage:
+  status:
+    patch:
+      default:
+        target: 95%
+    project:
+      default:
+        threshold: 1%

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.gitattributes
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.gitattributes
@@ -1,0 +1,1 @@
+*.cairo linguist-language=python

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- Briefly describe the issue you're experiencing. Tell us what you were trying to do and what happened instead. -->
+
+<!-- Remember, this is not a place to ask for help debugging code. For that, we welcome you in the OpenZeppelin Community Forum: https://forum.openzeppelin.com/. -->
+
+**📝 Details**
+
+<!-- Describe the problem you have been experiencing in more detail. Include as much information as you think is relevant. Keep in mind that transactions can fail for many reasons; context is key here. -->
+
+**🔢 Code to reproduce bug**
+
+<!-- We will be able to better help if you provide a minimal example that triggers the bug. -->

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**🧐 Motivation**
+<!-- Is your feature request related to a specific problem? Is it just a crazy idea? Tell us about it! -->
+
+**📝 Details**
+<!-- Please describe your feature request in detail. -->
+

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/coverage.yml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/coverage.yml
@@ -1,0 +1,52 @@
+name: Coverage and linter
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+
+jobs:
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Markdown Linter
+      uses: docker://avtodev/markdown-lint:v1
+      with:
+        args: README.md CONTRIBUTING.md docs
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: [linter]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest tox
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Run tests and collect coverage
+      run: |
+        tox -e coverage -- --xml
+    - name: Upload coverage reports to Codecov with GitHub Action
+      uses: codecov/codecov-action@v3

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/release.yml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Build and Release
+
+on:
+  workflow_run:
+    workflows: [Test]
+    types:
+      - completed
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Build package
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+    - run: python -m pip install -U setuptools
+    - run: python -m pip install -e .[testing]
+    - name: Build package
+      run: tox -e build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist
+
+  dist_upload:
+    runs-on: ubuntu-latest
+    needs: [dist]
+    name: Upload to PyPi
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.pypi_token }}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/test.yml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    tags:
+    - "v*"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get commits
+      id: commits
+      run: |
+        echo "MAIN=$(git show -s --format="%H" origin/main)" >> $GITHUB_OUTPUT
+        echo "TAG=$(git rev-list -n 1 ${GITHUB_REF#refs/*/})" >> $GITHUB_OUTPUT
+    - name: Print commits
+      run: |
+        echo "Main commit: ${{ steps.commits.outputs.MAIN }}"
+        echo "Tag commit: ${{ steps.commits.outputs.TAG }}"
+    - name: Compare commits
+      if: ${{ steps.commits.outputs.MAIN != steps.commits.outputs.TAG }}
+      uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0 # v6.3.3
+      with:
+        script: |
+            core.setFailed('Tagged commit does not match main')
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [validate]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest tox
+    - name: Run tests
+      run: |
+        tox

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.gitignore
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.gitignore
@@ -1,0 +1,143 @@
+artifacts/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# nile
+*node.json*
+
+# node
+**/node_modules/
+
+# docs
+docs/build/
+
+# vscode
+.vscode/

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/.markdownlintrc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/.markdownlintrc
@@ -1,0 +1,8 @@
+{
+    // Disable line length check to enable paragraphs without internal line breaks.
+    // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length
+    "MD013": false,
+    // Disable inline HTML check to enable duplicate headers with separate ids.
+    // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html
+    "MD033": false
+} 

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/CONTRIBUTING.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to OpenZeppelin Contracts for Cairo
+
+We really appreciate and value contributions to OpenZeppelin Contracts for Cairo. Please take 5' to review the items listed below to make sure that your contributions are merged as soon as possible.
+
+## Contribution guidelines
+
+Before starting development, please [create an issue](https://github.com/OpenZeppelin/cairo-contracts/issues/new/choose) to open the discussion, validate that the PR is wanted, and coordinate overall implementation details.
+
+Also, consider that snake case is used for Cairo development in general due to its strong Python bias.
+This project follows our [Extensibility pattern](https://docs.openzeppelin.com/contracts-cairo/extensibility), camelCasing all exposed function names and their parameters:
+
+```cairo
+@external
+func exposedFunc(paramOne, paramTwo){
+}
+```
+
+All internal and otherwise unexposed functions should resort to snake_case:
+
+```cairo
+func internal_func(param_one, param_two){
+}
+```
+
+Compare our preset contracts with the libraries from which they're derived such as the [ERC20 preset](./src/openzeppelin/token/erc20/presets/ERC20.cairo) and [ERC20 library](./src/openzeppelin/token/erc20/presets/ERC20.cairo) for full examples.
+See [Function names and coding style](https://docs.openzeppelin.com/contracts-cairo/0.4.0/extensibility#function_names_and_coding_style) for more information.
+
+And make sure to always include tests and documentation for the new developments. Please consider the following conventions:
+
+- Naming
+  - Libraries should be named `library.cairo`, e.g. `erc20/library.cairo`
+  - Contracts should be PascalCased i.e. `MyContract.cairo`
+  - Interfaces should be prefixed with an `I`, as in `IAccount.cairo`
+  - Test modules should begin with `test_` followed by the contract name i.e. `test_MyContract.py`
+
+- Structure
+  - Libraries should cede their names to their parent directory and are named `library.cairo` instead
+  - Interfaces should be alongside the library that the interface defines
+  - Preset contracts should be within a `presets` directory of the library to which they are a preset
+  - Here are example paths:
+    - `openzeppelin.token.erc20.library`
+    - `openzeppelin.token.erc20.IERC20`
+    - `openzeppelin.token.erc20.presets.ERC20Mintable`
+  - And a visual guide:
+
+```python
+    openzeppelin
+          └──token
+               └── erc20
+                     ├── library.cairo
+                     ├── IERC20.cairo
+                     └── presets
+                            └── ERC20Mintable.cairo
+```
+
+- Preset contract testing
+  - Though, inheritance is not possible in Cairo, this repo utilizes inheritance for testing. This proves useful for testing multiple contracts that stem from the same base library. For example, the preset contracts [ERC20Mintable](./src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo) and [ERC20Burnable](./src/openzeppelin/token/erc20/presets/ERC20Burnable.cairo) both share the base ERC20 functionality. To reduce code repetition, we follow these guidelines:
+    - `BaseSuites`
+      - module names are not prefixed with `test_`
+      - set base tests inside a class
+      - class name should not be prefixed with `Test`; otherwise, these tests run twice
+
+    - test modules
+      - define the base fixture (`contract_factory`) and any other fixtures not used in the base suite i.e. `erc721_minted`
+      - define the test class and inherit the base class i.e. `class TestERC20(OwnableBase)`
+      - add tests specific to the preset flavor within the test class
+
+    - fixtures
+      - are not defined in the base suite but are passed, unpacked, and used
+      - are defined in the tests where they are used
+        - for modularity, the basic contract factory fixture is always called `contract_factory`
+
+## Creating Pull Requests (PRs)
+
+As a contributor, you are expected to fork this repository, work on your own fork and then submit pull requests. The pull requests will be reviewed and eventually merged into the main repo. See ["Fork-a-Repo"](https://help.github.com/articles/fork-a-repo/) for how this works.
+
+## A typical workflow
+
+1. Make sure your fork is up to date with the main repository:
+
+    ```sh
+    cd cairo-contracts
+    git remote add upstream https://github.com/OpenZeppelin/cairo-contracts.git
+    git fetch upstream
+    git pull --rebase upstream main
+    ```
+
+    > NOTE: The directory `cairo-contracts` represents your fork's local copy.
+
+2. Branch out from `main` into `fix/some-bug-short-description-#123` (ex: `fix/typos-in-docs-#123`):
+
+    (Postfixing #123 will associate your PR with the issue #123 and make everyone's life easier =D)
+
+    ```sh
+    git checkout -b fix/some-bug-short-description-#123
+    ```
+
+3. Make your changes, add your files, update documentation ([see Documentation section](#documentation)), commit, and push to your fork.
+
+    ```sh
+    git add SomeFile.js
+    git commit "Fix some bug short description #123"
+    git push origin fix/some-bug-short-description-#123
+    ```
+
+4. Run tests, linter, etc. This can be done by running local continuous integration and make sure it passes. We recommend to use a [python virtual environment](https://docs.python.org/3/tutorial/venv.html).
+
+    ```bash
+    # install tox from testing dependencies
+    pip install .[testing] # '.[testing]' in zsh
+
+    # run tests
+    tox
+
+    # stop the build if there are Markdown documentation errors
+    tox -e lint
+    ```
+
+5. Go to [github.com/OpenZeppelin/cairo-contracts](https://github.com/OpenZeppelin/cairo-contracts) in your web browser and issue a new pull request.
+    Begin the body of the PR with "Fixes #123" or "Resolves #123" to link the PR to the issue that it is resolving.
+    *IMPORTANT* Read the PR template very carefully and make sure to follow all the instructions. These instructions
+    refer to some very important conditions that your PR must meet in order to be accepted, such as making sure that all PR checks pass.
+
+6. Maintainers will review your code and possibly ask for changes before your code is pulled in to the main repository. We'll check that all tests pass, review the coding style, and check for general code correctness. If everything is OK, we'll merge your pull request and your code will be part of OpenZeppelin Contracts for Cairo.
+
+    *IMPORTANT* Please pay attention to the maintainer's feedback, since its a necessary step to keep up with the standards OpenZeppelin Contracts attains to.
+
+## Documentation
+
+Before submitting the PR, you must update the corresponding documentation entries in the docs folder. In the future we may use something similar to solidity-docgen to automatically generate docs, but for now we are updating .adoc entries manually.
+
+If you want to run the documentation UI locally:
+
+1. Change directory into docs inside the project and run npm install.
+
+    ```bash
+    cd docs && npm i
+    ```
+
+2. Build the docs and run the local server (default to localhost:8080). This will watch for changes in the docs/module folder, and update the UI accordingly.
+
+    ```bash
+    npm run docs:watch
+    ```
+
+## Integration tests
+
+Currently, [starknet's test suite](https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/starknet/testing/starknet.py) has important differences with public networks. Like [not checking signature hints toward the end of the tx flow](https://github.com/OpenZeppelin/cairo-contracts/issues/386).
+
+That's why we strongly suggest testing new features against a testnet before submitting the PR, to make sure that everything works as expected in a real environment.
+
+We are looking into defining a better process for these integration tests, but for now the PR author/contributor must suggest an approach to test the feature when applicable, which has to be agreed and reproduced by the reviewer.
+
+## All set
+
+If you have any questions, feel free to post them to github.com/OpenZeppelin/cairo-contracts/issues.
+
+Finally, if you're looking to collaborate and want to find easy tasks to start, look at the issues we marked as ["Good first issue"](https://github.com/OpenZeppelin/cairo-contracts/labels/good%20first%20issue).
+
+Thanks for your time and code!

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/LICENSE
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 OpenZeppelin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/MANIFEST.in
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/ *.cairo

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/PULL_REQUEST_TEMPLATE.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Thank you for your interest in contributing to OpenZeppelin! -->
+
+<!-- Consider opening an issue for discussion prior to submitting a PR. -->
+<!-- New features will be merged faster if they were first discussed and designed with the team. -->
+
+Fixes #??? <!-- Fill in with issue number -->
+
+<!-- Describe the changes introduced in this pull request. -->
+<!-- Include any context necessary for understanding the PR's purpose. -->
+
+
+#### PR Checklist
+
+<!-- Before merging the pull request all of the following must be complete. -->
+<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
+<!-- Some of the items may not apply. -->
+
+- [ ] Tests
+- [ ] Tried the feature on a public network
+- [ ] Documentation

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/README.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/README.md
@@ -1,0 +1,300 @@
+# OpenZeppelin Contracts for Cairo
+
+[![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/coverage.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/coverage.yml)
+[![codecov](https://codecov.io/github/OpenZeppelin/cairo-contracts/branch/main/graph/badge.svg?token=LFSZH8RPOL)](https://codecov.io/github/OpenZeppelin/cairo-contracts)
+
+**A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
+
+## Usage
+
+> ## ⚠️ WARNING! ⚠️
+>
+> This repo contains highly experimental code.
+> Expect rapid iteration.
+> **Use at your own risk.**
+
+### First time?
+
+Before installing Cairo on your machine, you need to install `gmp`:
+
+```bash
+sudo apt install -y libgmp3-dev # linux
+brew install gmp # mac
+```
+
+> If you have any troubles installing gmp on your Apple M1 computer, [here’s a list of potential solutions](https://github.com/OpenZeppelin/nile/issues/22).
+
+### Set up your project
+
+Create a directory for your project, then `cd` into it and create a Python virtual environment.
+
+```bash
+mkdir my-project
+cd my-project
+python3 -m venv env
+source env/bin/activate
+```
+
+Install the [Nile](https://github.com/OpenZeppelin/nile) development environment and then run `init` to kickstart a new project. Nile will create the project directory structure and install [the Cairo language](https://www.cairo-lang.org/docs/quickstart.html), a [local network](https://github.com/Shard-Labs/starknet-devnet/), and a [testing framework](https://docs.pytest.org/en/6.2.x/).
+
+```bash
+pip install cairo-nile
+nile init
+```
+
+### Install the library
+
+```bash
+pip install openzeppelin-cairo-contracts
+```
+
+> ⚠️ Warning! ⚠️  
+Installing directly the `main` branch may contain incomplete or breaking implementations, download [official releases](https://github.com/OpenZeppelin/cairo-contracts/releases/) only.
+
+### Use a basic preset
+
+Presets are ready-to-use contracts that you can deploy right away. They also serve as examples of how to use library modules. [Read more about presets](https://docs.openzeppelin.com/contracts-cairo/0.6.1/extensibility#presets).
+
+```cairo
+// contracts/MyToken.cairo
+
+%lang starknet
+
+from openzeppelin.token.erc20.presets.ERC20 import (
+    constructor,
+    name,
+    symbol,
+    totalSupply,
+    decimals,
+    balanceOf,
+    allowance,
+    transfer,
+    transferFrom,
+    approve,
+    increaseAllowance,
+    decreaseAllowance
+)
+```
+
+Compile and deploy it right away:
+
+```bash
+nile compile
+
+nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --alias my_token
+```
+
+> Note that `<initial_supply>` is expected to be two integers i.e. `1` `0`. See [Uint256](https://docs.openzeppelin.com/contracts-cairo/0.6.1/utilities#uint256) for more information.
+
+### Write a custom contract using library modules
+
+[Read more about libraries](https://docs.openzeppelin.com/contracts-cairo/0.6.1/extensibility#libraries).
+
+```cairo
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from openzeppelin.security.pausable.library import Pausable
+from openzeppelin.token.erc20.library import ERC20
+
+(...)
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.transfer(recipient, amount);
+}
+```
+
+## Learn
+
+### Documentation
+
+Check out the [full documentation site](https://docs.openzeppelin.com/contracts-cairo)! Featuring:
+
+- [Accounts](https://docs.openzeppelin.com/contracts-cairo/0.6.1/accounts)
+- [ERC20](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc20)
+- [ERC721](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc721)
+- [ERC1155](https://docs.openzeppelin.com/contracts-cairo/0.6.1/erc1155)
+- [Contract extensibility pattern](https://docs.openzeppelin.com/contracts-cairo/0.6.1/extensibility)
+- [Proxies and upgrades](https://docs.openzeppelin.com/contracts-cairo/0.6.1/proxies)
+- [Security](https://docs.openzeppelin.com/contracts-cairo/0.6.1/security)
+- [Utilities](https://docs.openzeppelin.com/contracts-cairo/0.6.1/utilities)
+
+### Cairo
+
+- [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
+- [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
+- Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
+- [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
+
+### Nile
+
+- [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
+- [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
+
+## Development
+
+### Set up the project
+
+Clone the repository
+
+```bash
+git clone git@github.com:OpenZeppelin/cairo-contracts.git
+```
+
+`cd` into it and create a Python virtual environment:
+
+```bash
+cd cairo-contracts
+python3 -m venv env
+source env/bin/activate
+```
+
+Install dependencies:
+
+```bash
+python -m pip install .
+```
+
+### Compile the contracts
+
+```bash
+nile compile --directory src
+
+🤖 Compiling all Cairo contracts in the src directory
+🔨 Compiling src/openzeppelin/token/erc20/library.cairo
+🔨 Compiling src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo
+🔨 Compiling src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo
+🔨 Compiling src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo
+🔨 Compiling src/openzeppelin/token/erc20/presets/ERC20.cairo
+🔨 Compiling src/openzeppelin/token/erc20/IERC20.cairo
+🔨 Compiling src/openzeppelin/token/erc721/enumerable/library.cairo
+🔨 Compiling src/openzeppelin/token/erc721/library.cairo
+🔨 Compiling src/openzeppelin/token/erc721/utils/ERC721Holder.cairo
+🔨 Compiling src/openzeppelin/token/erc721/presets/ERC721MintablePausable.cairo
+🔨 Compiling src/openzeppelin/token/erc721/presets/ERC721MintableBurnable.cairo
+🔨 Compiling src/openzeppelin/token/erc721/presets/ERC721EnumerableMintableBurnable.cairo
+🔨 Compiling src/openzeppelin/token/erc721/IERC721.cairo
+🔨 Compiling src/openzeppelin/token/erc721/IERC721Metadata.cairo
+🔨 Compiling src/openzeppelin/token/erc721/IERC721Receiver.cairo
+🔨 Compiling src/openzeppelin/token/erc721/enumerable/IERC721Enumerable.cairo
+🔨 Compiling src/openzeppelin/access/ownable/library.cairo
+🔨 Compiling src/openzeppelin/security/reentrancyguard/library.cairo
+🔨 Compiling src/openzeppelin/security/safemath/library.cairo
+🔨 Compiling src/openzeppelin/security/pausable/library.cairo
+🔨 Compiling src/openzeppelin/security/initializable/library.cairo
+🔨 Compiling src/openzeppelin/utils/constants/library.cairo
+🔨 Compiling src/openzeppelin/introspection/erc165/library.cairo
+🔨 Compiling src/openzeppelin/introspection/erc165/IERC165.cairo
+🔨 Compiling src/openzeppelin/upgrades/library.cairo
+🔨 Compiling src/openzeppelin/upgrades/presets/Proxy.cairo
+🔨 Compiling src/openzeppelin/account/library.cairo
+🔨 Compiling src/openzeppelin/account/presets/EthAccount.cairo
+🔨 Compiling src/openzeppelin/account/presets/Account.cairo
+🔨 Compiling src/openzeppelin/account/presets/AddressRegistry.cairo
+🔨 Compiling src/openzeppelin/account/IAccount.cairo
+✅ Done
+```
+
+### Run tests
+
+Run tests using [tox](https://tox.wiki/en/latest/), tox automatically creates an isolated testing environment:
+
+```bash
+tox
+
+====================== test session starts ======================
+platform linux -- Python 3.7.2, pytest-7.1.2, py-1.11.0, pluggy-1.0.0
+rootdir: /home/readme/cairo-contracts, configfile: tox.ini
+plugins: asyncio-0.18.3, xdist-2.5.0, forked-1.4.0, web3-5.29.0, typeguard-2.13.3
+asyncio: mode=auto
+gw0 [185] / gw1 [185]
+......................................................................................
+......................................................................................
+............    [100%]
+```
+
+### Run Tests in Docker
+
+For M1 users or those who are having trouble with library/python versions you can alternatively run the tests within a docker container. Using the following as a Dockerfile placed in the root directory of the project:
+
+```dockerfile
+FROM python:3.7
+
+RUN pip install tox
+RUN mkdir cairo-contracts
+COPY . cairo-contracts
+WORKDIR cairo-contracts
+ENTRYPOINT tox
+```
+
+After its placed there run:
+
+```bash
+docker build -t cairo-tests .
+docker run cairo-tests
+```
+
+### Parallel Testing
+
+This repo utilizes the [pytest-xdist](https://pytest-xdist.readthedocs.io/en/latest/) plugin which runs tests in parallel. This feature increases testing speed; however, conflicts with a shared state can occur since tests do not run in order. To overcome this, independent cached versions of contracts being tested should be provisioned to each test case. Here's a simple fixture example:
+
+```python
+from utils import get_contract_class, cached_contract
+
+@pytest.fixture
+def foo_factory():
+    # get contract class
+    foo_cls = get_contract_class('Foo')
+
+    # deploy contract
+    starknet = await Starknet.empty()
+    foo = await starknet.deploy(contract_class=foo_cls)
+
+    # copy the state and cache contract
+    state = starknet.state.copy()
+    cached_foo = cached_contract(state, foo_cls, foo)
+
+    return cached_foo
+```
+
+See [Memoization](https://docs.openzeppelin.com/contracts-cairo/0.6.1/utilities#memoization) in the Utilities documentation for a more thorough example on caching contracts.
+
+> Note that this does not apply for stateless libraries such as SafeMath.
+
+## Security
+
+> ⚠️ Warning! ⚠️
+> This project is still in a very early and experimental phase. It has never been audited nor thoroughly reviewed for security vulnerabilities. Do not use in production.
+
+Refer to [SECURITY.md](SECURITY.md) for more details.
+
+## Contribute
+
+OpenZeppelin Contracts for Cairo exists thanks to its contributors. There are many ways you can participate and help build high quality software. Check out the [contribution](CONTRIBUTING.md) guide!
+
+### Markdown linter
+
+To keep the markdown files neat and easy to edit, we utilize DavidAnson's [markdownlint](https://github.com/DavidAnson/markdownlint) linter. You can find the listed rules [here](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md). Note that the following rules are disabled:
+
+- `MD013: line length`
+
+  - to enable paragraphs without internal line breaks
+
+- `MD033: inline HTML`
+
+  - to enable .md files to have duplicate headers and separate them by identifiers
+
+Before creating a PR, check that documentation changes are compliant with our markdown rules by running:
+
+```bash
+tox -e lint
+```
+
+## License
+
+OpenZeppelin Contracts for Cairo is released under the [MIT License](LICENSE).

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/RELEASING.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/RELEASING.md
@@ -1,0 +1,34 @@
+# Releasing
+
+Releasing checklist:
+
+(1) Write a changelog.
+
+(2) Run version bump script with the new version as an argument and open a PR.
+
+```sh
+python scripts/update_version.py v0.5.1
+```
+
+(3) Create and push a release branch.
+
+```txt
+git checkout -b release-v0.5.1
+git push release-v0.5.1
+```
+
+(4) Checkout the branch to be released. This should be `main` except in the event of a hotfix. For hotfixes, checkout the latest release branch.
+
+(5) Create a tag for the release.
+
+```sh
+git tag v0.5.1
+```
+
+(6) Push the tag to the main repository, [triggering the CI and release process](https://github.com/OpenZeppelin/cairo-contracts/blob/b27101eb826fae73f49751fa384c2a0ff3377af2/.github/workflows/python-app.yml#L60).
+
+```sh
+git push origin v0.5.1
+```
+
+(7) Finally, go to the repo's [releases page](https://github.com/OpenZeppelin/cairo-contracts/releases/) and [create a new one](https://github.com/OpenZeppelin/cairo-contracts/releases/new) with the new tag and the base branch as target (which should be `main` except in the event of a hotfix).

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/SECURITY.md
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/SECURITY.md
@@ -1,0 +1,4 @@
+> ⚠️ Warning! ⚠️
+> This project is still in a very early and experimental phase. It has never been audited nor thoroughly reviewed for security vulnerabilities. Do not use in production.
+
+Please report any security issues you find to security@openzeppelin.com.

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/antora.yml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/antora.yml
@@ -1,0 +1,5 @@
+name: contracts-cairo
+title: Contracts for Cairo
+version: 0.6.1
+nav:
+  - modules/ROOT/nav.adoc

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/nav.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/nav.adoc
@@ -1,0 +1,19 @@
+* xref:index.adoc[Overview]
+* xref:wizard.adoc[Wizard]
+* xref:extensibility.adoc[Extensibility]
+* xref:proxies.adoc[Proxies and Upgrades]
+
+* xref:accounts.adoc[Accounts]
+* xref:access.adoc[Access Control]
+
+* Tokens
+** xref:erc20.adoc[ERC20]
+** xref:erc721.adoc[ERC721]
+** xref:erc1155.adoc[ERC1155]
+
+* xref:security.adoc[Security]
+* xref:introspection.adoc[Introspection]
+* xref:udc.adoc[Universal Deployer Contract]
+* xref:utilities.adoc[Utilities]
+
+* xref:contracts::index.adoc[Contracts for Solidity]

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/access.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/access.adoc
@@ -1,0 +1,672 @@
+:ownable-cairo: link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/access/ownable/library.cairo[Ownable]
+
+:extensibility-pattern: xref:extensibility.adoc#the_pattern
+
+= Access
+
+CAUTION: Expect these modules to evolve.
+
+Access control--that is, "who is allowed to do this thing"--is incredibly important in the world of smart contracts.
+The access control of your contract may govern who can mint tokens, vote on proposals, freeze transfers, and many other things.
+It is therefore critical to understand how you implement it, lest someone else https://blog.openzeppelin.com/on-the-parity-wallet-multisig-hack-405a8c12e8f7/[steals your whole system].
+
+== Table of Contents
+
+* <<ownable,Ownable>>
+ ** <<quickstart,Quickstart>>
+ ** <<ownable_library_api,Ownable library API>>
+ ** <<ownable_events,Ownable events>>
+* <<accesscontrol,AccessControl>>
+ ** <<usage,Usage>>
+ ** <<granting_and_revoking_roles,Granting and revoking roles>>
+ ** <<creating_role_identifiers,Creating role identifiers>>
+ ** <<accesscontrol_library_api,AccessControl library API>>
+ ** <<accesscontrol_events,AccessControl events>>
+
+== Ownable
+
+The most common and basic form of access control is the concept of ownership: there's an account that is the `owner` of a contract and can do administrative tasks on it.
+This approach is perfectly reasonable for contracts that have a single administrative user.
+
+OpenZeppelin Contracts for Cairo provides {ownable-cairo} for implementing ownership in your contracts.
+
+=== Quickstart
+
+Integrating {ownable-cairo} into a contract first requires assigning an owner.
+The implementing contract's constructor should set the initial owner by passing the owner's address to Ownable's <<initializer,initializer>> like this:
+
+[,cairo]
+----
+from openzeppelin.access.ownable.library import Ownable
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) {
+    Ownable.initializer(owner);
+    return ();
+}
+----
+
+To restrict a function's access to the owner only, add in the `assert_only_owner` method:
+
+[,cairo]
+----
+from openzeppelin.access.ownable.library import Ownable
+
+func protected_function{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.assert_only_owner();
+    return ();
+}
+----
+
+=== Ownable library API
+
+[,cairo]
+----
+func initializer(owner: felt) {
+}
+
+func assert_only_owner() {
+}
+
+func owner() -> (owner: felt) {
+}
+
+func transfer_ownership(new_owner: felt) {
+}
+
+func renounce_ownership() {
+}
+
+func _transfer_ownership(new_owner: felt) {
+}
+----
+
+==== `initializer`
+
+Initializes Ownable access control and should be called in the implementing contract's constructor.
+Assigns `owner` as the initial owner address of the contract.
+
+This must be called only once.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+----
+
+Returns: None.
+
+==== `assert_only_owner`
+
+Reverts if called by any account other than the owner.
+In case of renounced ownership, any call from the default zero address will also be reverted.
+
+Parameters: None.
+
+Returns: None.
+
+==== `owner`
+
+Returns the address of the current owner.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+owner: felt
+----
+
+==== `transfer_ownership`
+
+Transfers ownership of the contract to a new account (`new_owner`).
+Can only be called by the current owner.
+
+Emits a <<ownershiptransferred,`OwnershipTransferred`>> event.
+
+Parameters:
+
+[,cairo]
+----
+new_owner: felt
+----
+
+Returns: None.
+
+==== `renounce_ownership`
+
+Leaves the contract without owner.
+It will not be possible to call functions with `assert_only_owner` anymore.
+Can only be called by the current owner.
+
+Emits a <<ownershiptransferred,`OwnershipTransferred`>> event.
+
+Parameters: None.
+
+Returns: None.
+
+[#transfer-ownership-internal]
+==== `_transfer_ownership`
+
+Transfers ownership of the contract to a new account (`new_owner`). {extensibility-pattern}[`internal`] function without access restriction.
+
+Emits a <<ownershiptransferred,`OwnershipTransferred`>> event.
+
+Parameters:
+
+[,cairo]
+----
+new_owner: felt
+----
+
+Returns: None.
+
+=== Ownable events
+
+[,cairo]
+----
+func OwnershipTransferred(previousOwner: felt, newOwner: felt) {
+}
+----
+
+==== OwnershipTransferred
+
+Emitted when ownership of a contract is transferred from `previousOwner` to `newOwner`.
+
+Parameters:
+
+[,cairo]
+----
+previousOwner: felt
+newOwner: felt
+----
+
+== AccessControl
+
+While the simplicity of ownership can be useful for simple systems or quick prototyping, different levels of authorization are often needed.
+You may want for an account to have permission to ban users from a system, but not create new tokens.
+https://en.wikipedia.org/wiki/Role-based_access_control[Role-Based Access Control (RBAC)] offers flexibility in this regard.
+
+In essence, we will be defining multiple roles, each allowed to perform different sets of actions.
+An account may have, for example, 'moderator', 'minter' or 'admin' roles, which you will then check for instead of simply using <<assert_only_owner,assert_only_owner>>.
+This check can be enforced through <<assert_only_role,assert_only_role>>.
+Separately, you will be able to define rules for how accounts can be granted a role, have it revoked, and more.
+
+Most software uses access control systems that are role-based: some users are regular users, some may be supervisors or managers, and a few will often have administrative privileges.
+
+=== Usage
+
+For each role that you want to define, you will create a new _role identifier_ that is used to grant, revoke, and check if an account has that role (see <<creating_role_identifiers,Creating role identifiers>> for information on creating identifiers).
+
+Here's a simple example of implementing `AccessControl` on a portion of an link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20.cairo[ERC20 token contract] which defines and sets the 'minter' role:
+
+[,cairo]
+----
+from openzeppelin.token.erc20.library import ERC20
+
+from openzeppelin.access.accesscontrol.library import AccessControl
+
+
+const MINTER_ROLE = 0x4f96f87f6963bb246f2c30526628466840c642dc5c50d5a67777c6cc0e44ab5
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, minter: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    AccessControl.initializer();
+    AccessControl._grant_role(MINTER_ROLE, minter);
+    return ();
+}
+
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(MINTER_ROLE);
+    ERC20._mint(to, amount);
+    return ();
+}
+----
+
+CAUTION: Make sure you fully understand how <<accesscontrol,AccessControl>> works before using it on your system, or copy-pasting the examples from this guide.
+
+While clear and explicit, this isn't anything we wouldn't have been able to achieve with <<ownable,Ownable>>.
+Indeed, where `AccessControl` shines is in scenarios where granular permissions are required, which can be implemented by defining _multiple_ roles.
+
+Let's augment our ERC20 token example by also defining a 'burner' role, which lets accounts destroy tokens, and by using `assert_only_role`:
+
+[,cairo]
+----
+from openzeppelin.token.erc20.library import ERC20
+
+from openzeppelin.access.accesscontrol.library import AccessControl
+
+
+const MINTER_ROLE = 0x4f96f87f6963bb246f2c30526628466840c642dc5c50d5a67777c6cc0e44ab5
+const BURNER_ROLE = 0x7823a2d975ffa03bed39c38809ec681dc0ae931ebe0048c321d4a8440aed509
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, minter: felt, burner: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    AccessControl.initializer();
+    AccessControl._grant_role(MINTER_ROLE, minter);
+    AccessControl._grant_role(BURNER_ROLE, burner);
+    return ();
+}
+
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(MINTER_ROLE);
+    ERC20._mint(to, amount);
+    return ();
+}
+
+@external
+func burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(BURNER_ROLE);
+    ERC20._burn(from_, amount);
+    return ();
+}
+----
+
+So clean!
+By splitting concerns this way, more granular levels of permission may be implemented than were possible with the simpler ownership approach to access control.
+Limiting what each component of a system is able to do is known as the https://en.wikipedia.org/wiki/Principle_of_least_privilege[principle of least privilege], and is a good security practice.
+Note that each account may still have more than one role, if so desired.
+
+=== Granting and revoking roles
+
+The ERC20 token example above uses `_grant_role`, an {extensibility-pattern}[`internal`] function that is useful when programmatically assigning roles (such as during construction).
+But what if we later want to grant the 'minter' role to additional accounts?
+
+By default, *accounts with a role cannot grant it or revoke it from other accounts*: all having a role does is making the `assert_only_role` check pass.
+To grant and revoke roles dynamically, you will need help from the role's _admin_.
+
+Every role has an associated admin role, which grants permission to call the `grant_role` and `revoke_role` functions.
+A role can be granted or revoked by using these if the calling account has the corresponding admin role.
+Multiple roles may have the same admin role to make management easier.
+A role's admin can even be the same role itself, which would cause accounts with that role to be able to also grant and revoke it.
+
+This mechanism can be used to create complex permissioning structures resembling organizational charts, but it also provides an easy way to manage simpler applications.
+`AccessControl` includes a special role with the role identifier of `0`, called `DEFAULT_ADMIN_ROLE`, which acts as the *default admin role for all roles*.
+An account with this role will be able to manage any other role, unless `_set_role_admin` is used to select a new admin role.
+
+Let's take a look at the ERC20 token example, this time taking advantage of the default admin role:
+
+[,cairo]
+----
+from openzeppelin.token.erc20.library import ERC20
+
+from openzeppelin.access.accesscontrol.library import AccessControl
+
+from openzeppelin.utils.constants import DEFAULT_ADMIN_ROLE
+
+
+const MINTER_ROLE = 0x4f96f87f6963bb246f2c30526628466840c642dc5c50d5a67777c6cc0e44ab5
+const BURNER_ROLE = 0x7823a2d975ffa03bed39c38809ec681dc0ae931ebe0048c321d4a8440aed509
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, admin: felt,
+) {
+    ERC20.initializer(name, symbol, decimals);
+    AccessControl.initializer();
+
+    AccessControl._grant_role(DEFAULT_ADMIN_ROLE, admin);
+    return ();
+}
+
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(MINTER_ROLE);
+    ERC20._mint(to, amount);
+    return ();
+}
+
+@external
+func burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, amount: Uint256
+) {
+    AccessControl.assert_only_role(BURNER_ROLE);
+    ERC20._burn(from_, amount);
+    return ();
+}
+----
+
+Note that, unlike the previous examples, no accounts are granted the 'minter' or 'burner' roles.
+However, because those roles' admin role is the default admin role, and that role was granted to the 'admin', that same account can call `grant_role` to give minting or burning permission, and `revoke_role` to remove it.
+
+Dynamic role allocation is often a desirable property, for example in systems where trust in a participant may vary over time.
+It can also be used to support use cases such as https://en.wikipedia.org/wiki/Know_your_customer[KYC], where the list of role-bearers may not be known up-front, or may be prohibitively expensive to include in a single transaction.
+
+The following example uses the link:https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/tests/mocks/AccessControl.cairo[AccessControl mock contract] which exposes the role management functions.
+To grant and revoke roles in Python, for example:
+
+[,python]
+----
+MINTER_ROLE = 0x4f96f87f6963bb246f2c30526628466840c642dc5c50d5a67777c6cc0e44ab5
+BURNER_ROLE = 0x7823a2d975ffa03bed39c38809ec681dc0ae931ebe0048c321d4a8440aed509
+
+# grants MINTER_ROLE and BURNER_ROLE to account1 and account2 respectively
+await signer.send_transactions(
+    admin, [
+        (accesscontrol.contract_address, 'grantRole', [MINTER_ROLE, account1.contract_address]),
+        (accesscontrol.contract_address, 'grantRole', [BURNER_ROLE, account2.contract_address])
+    ]
+)
+
+# revokes MINTER_ROLE from account1
+await signer.send_transaction(
+    admin,
+    accesscontrol.contract_address,
+    'revokeRole',
+    [MINTER_ROLE, account1.contract_address]
+)
+----
+
+=== Creating role identifiers
+
+In the Solidity implementation of AccessControl, contracts generally refer to the https://docs.soliditylang.org/en/latest/units-and-global-variables.html?highlight=keccak256#mathematical-and-cryptographic-functions[keccak256 hash] of a role as the role identifier.
+For example:
+
+[,solidity]
+----
+bytes32 public constant SOME_ROLE = keccak256("SOME_ROLE")
+----
+
+These identifiers take up 32 bytes (256 bits).
+
+Cairo field elements store a maximum of 252 bits.
+Even further, a declared _constant_ field element in a StarkNet contract stores even less (see https://github.com/starkware-libs/cairo-lang/blob/release-v0.6.1/src/starkware/cairo/lang/cairo_constants.py#L1[cairo_constants]).
+With this discrepancy, this library maintains an agnostic stance on how contracts should create identifiers.
+Some ideas to consider:
+
+* Use the first or last 251 bits of keccak256 hash digests.
+* Use Cairo's https://github.com/starkware-libs/cairo-lang/blob/master/src/starkware/cairo/common/hash.cairo[hash2].
+
+=== AccessControl library API
+
+[,cairo]
+----
+func initializer() {
+}
+
+func assert_only_role(role: felt) {
+}
+
+func has_role(role: felt, user: felt) -> (has_role: felt) {
+}
+
+func get_role_admin(role: felt) -> (admin: felt) {
+}
+
+func grant_role(role: felt, user: felt) {
+}
+
+func revoke_role(role: felt, user: felt) {
+}
+
+func renounce_role(role: felt, user: felt) {
+}
+
+func _grant_role(role: felt, user: felt) {
+}
+
+func _revoke_role(role: felt, user: felt) {
+}
+
+func _set_role_admin(role: felt, admin_role: felt) {
+}
+----
+
+[#initializer-accesscontrol]
+==== `initializer`
+
+Initializes AccessControl and should be called in the implementing contract's constructor.
+
+This must only be called once.
+
+Parameters: None.
+
+Returns: None.
+
+==== `assert_only_role`
+
+Checks that an account has a specific role.
+Reverts with a message including the required role.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+----
+
+Returns: None.
+
+==== has_role
+
+Returns `TRUE` if `user` has been granted `role`, `FALSE` otherwise.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns:
+
+[,cairo]
+----
+has_role: felt
+----
+
+==== `get_role_admin`
+
+Returns the admin role that controls `role`.
+See <<grant_role,grant_role>> and <<revoke_role,revoke_role>>.
+
+To change a role's admin, use <<set_role_admin,`_set_role_admin`>>.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+----
+
+Returns:
+
+[,cairo]
+----
+admin: felt
+----
+
+==== `grant_role`
+
+Grants `role` to `user`.
+
+If `user` had not been already granted `role`, emits a <<rolegranted,RoleGranted>> event.
+
+Requirements:
+
+* The caller must have ``role``'s admin role.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns: None.
+
+==== `revoke_role`
+
+Revokes `role` from `user`.
+
+If `user` had been granted `role`, emits a <<rolerevoked,RoleRevoked>> event.
+
+Requirements:
+
+* The caller must have ``role``'s admin role.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns: None.
+
+==== `renounce_role`
+
+Revokes `role` from the calling `user`.
+
+Roles are often managed via <<grant_role,grant_role>> and <<revoke_role,revoke_role>>: this function's purpose is to provide a mechanism for accounts to lose their privileges if they are compromised (such as when a trusted device is misplaced).
+
+If the calling `user` had been revoked `role`, emits a <<rolerevoked,RoleRevoked>> event.
+
+Requirements:
+
+* The caller must be `user`.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns: None.
+
+[#grantrole-internal]
+==== `_grant_role`
+
+Grants `role` to `user`.
+
+{extensibility-pattern}[`internal`] function without access restriction.
+
+Emits a <<rolegranted,RoleGranted>> event.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns: None.
+
+[#revokerole-internal]
+==== `_revoke_role`
+
+Revokes `role` from `user`.
+
+{extensibility-pattern}[`internal`] function without access restriction.
+
+Emits a <<rolerevoked,RoleRevoked>> event.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+user: felt
+----
+
+Returns: None.
+
+[#setroleadmin]
+==== `_set_role_admin`
+
+{extensibility-pattern}[`internal`] function that sets `admin_role` as ``role``'s admin role.
+
+Emits a <<roleadminchanged,RoleAdminChanged>> event.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+admin_role: felt
+----
+
+Returns: None.
+
+=== AccessControl events
+
+[,cairo]
+----
+func RoleGranted(role: felt, account: felt, sender: felt) {
+}
+
+func RoleRevoked(role: felt, account: felt, sender: felt) {
+}
+
+func RoleAdminChanged(role: felt, previousAdminRole: felt, newAdminRole: felt) {
+}
+----
+
+==== `RoleGranted`
+
+Emitted when `account` is granted `role`.
+
+`sender` is the account that originated the contract call, an admin role bearer.
+
+Parameters:
+
+[,cairo]
+----
+role: felt
+account: felt
+sender: felt
+----
+
+==== `RoleRevoked`
+
+Emitted when account is revoked role.
+
+`sender` is the account that originated the contract call:
+
+* If using <<revoke_role,revoke_role>>, it is the admin role bearer.
+* If using <<renounce_role,renounce_role>>, it is the role bearer (i.e.
+`account`).
+
+[,cairo]
+----
+role: felt
+account: felt
+sender: felt
+----
+
+==== `RoleAdminChanged`
+
+Emitted when `newAdminRole` is set as ``role``'s admin role, replacing `previousAdminRole`.
+
+`DEFAULT_ADMIN_ROLE` is the starting admin for all roles, despite `RoleAdminChanged` not being emitted signaling this.
+
+[,cairo]
+----
+role: felt
+previousAdminRole: felt
+newAdminRole: felt
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/accounts.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/accounts.adoc
@@ -1,0 +1,632 @@
+:test-signers: https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/tests/signers.py
+
+= Accounts
+
+Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
+
+Instead, signature validation has to be done at the contract level.
+To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
+
+For a general overview of the account abstraction, see StarkWare's https://medium.com/starkware/starknet-alpha-0-10-0-923007290470[StarkNet Alpha 0.10].
+A more detailed discussion on the topic can be found in https://community.starknet.io/t/starknet-account-abstraction-model-part-1/781[StarkNet Account Abstraction Part 1].
+
+== Table of Contents
+
+* <<quickstart,Quickstart>>
+* <<account_entrypoints,Account entrypoints>>
+ ** <<counterfactual_deployments,`Counterfactual deployments`>>
+* <<standard_interface,Standard interface>>
+* <<keys_signatures_and_signers,Keys, signatures and signers>>
+** <<signature_validation, Signature validation>>
+ ** <<signer,Signer>>
+ ** <<mocksigner_utility,MockSigner utility>>
+ ** <<mockethsigner_utility,MockEthSigner utility>>
+* <<call_and_accountcallarray_format,Call and AccountCallArray format>>
+ ** <<call,Call>>
+ ** <<accountcallarray,AccountCallArray>>
+* <<multicall_transactions,Multicall transactions>>
+* <<api_specification,API Specification>>
+ ** <<constructor, `constructor`>>
+ ** <<getpublickey,`getPublicKey`>>
+ ** <<supportsinterface,`supportsInterface`>>
+ ** <<setpublickey,`setPublicKey`>>
+ ** <<isvalidsignature,`isValidSignature`>>
+ ** <<validate,`\\__validate__`>>
+ ** <<validate_declare,`\\__validate_declare__`>>
+ ** <<validate_deploy,`\\__validate_deploy__`>>
+ ** <<execute,`\\__execute__`>>
+* <<presets,Presets>>
+ ** <<account,Account>>
+ ** <<eth_account,Eth Account>>
+* <<account_introspection_with_erc165,Account introspection with ERC165>>
+* <<extending_the_account_contract,Extending the Account contract>>
+* <<l1_escape_hatch_mechanism,L1 escape hatch mechanism>>
+* <<paying_for_gas,Paying for gas>>
+
+== Quickstart
+
+The general workflow is:
+
+. Account contract is deployed to StarkNet.
+. Signed transactions can now be sent to the Account contract which validates and executes them.
+
+In Python, this would look as follows:
+
+[,python]
+----
+from starkware.starknet.testing.starknet import Starknet
+from utils import get_contract_class
+from signers import MockSigner
+
+signer = MockSigner(123456789987654321)
+
+starknet = await Starknet.empty()
+
+# 1. Deploy Account
+account = await starknet.deploy(
+    get_contract_class("Account"),
+    constructor_calldata=[signer.public_key]
+)
+
+# 2. Send transaction through Account
+await signer.send_transaction(account, some_contract_address, 'some_function', [some_parameter])
+----
+
+== Account entrypoints
+
+Account contracts have only three entry points for all user interactions:
+
+1. <<validate_declare,`\\__validate_declare__`>> validates the declaration signature prior to the declaration.
+As of Cairo v0.10.0, contract classes should be declared from an Account contract.
+
+2. <<validate,`\\__validate__`>> verifies the transaction signature before executing the transaction with `\\__execute__`.
+
+3. <<execute,`\\__execute__`>> acts as the state-changing entry point for all user interaction with any contract, including managing the account contract itself.
+That's why if you want to change the public key controlling the Account, you would send a transaction targeting the very Account contract:
+
+[,python]
+----
+await signer.send_transaction(
+    account,
+    account.contract_address,
+    'set_public_key',
+    [NEW_KEY]
+)
+----
+
+Or if you want to update the Account's L1 address on the `AccountRegistry` contract, you would
+
+[,python]
+----
+await signer.send_transaction(account, registry.contract_address, 'set_L1_address', [NEW_ADDRESS])
+----
+
+NOTE: You can read more about how messages are structured and hashed in the https://github.com/OpenZeppelin/cairo-contracts/discussions/24[Account message scheme  discussion].
+For more information on the design choices and implementation of multicall, you can read the https://github.com/OpenZeppelin/cairo-contracts/discussions/27[How should Account multicall work discussion].
+
+The `\\__validate__` and `\\__execute__` methods accept the same arguments; however, `\\__execute__` returns a transaction response:
+
+[,cairo]
+----
+func __validate__(
+    call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) {
+}
+
+func __execute__(
+    call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+) -> (response_len: felt, response: felt*) {
+}
+----
+
+Where:
+
+* `call_array_len` is the number of calls.
+* `call_array` is an array representing each `Call`.
+* `calldata_len` is the number of calldata parameters.
+* `calldata` is an array representing the function parameters.
+
+NOTE: The scheme of building multicall transactions within the `\\__execute__` method will change once StarkNet allows for pointers in struct arrays.
+In which case, multiple transactions can be passed to (as opposed to built within) `\\__execute__`.
+
+There's a fourth canonical entrypoint for accounts, the `\\__validate_deploy__` method. It is **only callable by the protocol** during the execution of a `DeployAccount` type of transaction, but not by any other contract. This entrypoint is for counterfactual deployments.
+
+=== Counterfactual Deployments
+
+Counterfactual means something that hasn't happened.
+
+A deployment is said to be counterfactual when the deployed contract pays for it. It's called like this because we need to send the funds to the address before deployment. A deployment that hasn't happened.
+
+The steps are the following:
+
+1. Precompute the `address` given a `class_hash`, `salt`, and constructor `calldata`.
+2. Send funds to `address`.
+3. Send a `DeployAccount` type transaction.
+4. The protocol will then validate with `\\__validate_deploy__`.
+5. If successful, the protocol deploys the contract and the contract itself pays for the transaction.
+
+Since `address` will ultimately depend on the `class_hash` and `calldata`, it's safe for the protocol to validate the signature and spend the funds on that address.
+
+== Standard interface
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/account/IAccount.cairo[`IAccount.cairo`] contract interface contains the standard account interface proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/41[#41] and adopted by OpenZeppelin and Argent.
+It implements https://eips.ethereum.org/EIPS/eip-1271[EIP-1271] and it is agnostic of signature validation. Further, nonce management is handled on the protocol level.
+
+NOTE: `\\__validate_deploy__` is not part of the interface since it's only callable by the protocol. Also contracts don't need to implement it to be considered accounts.
+
+[,cairo]
+----
+struct Call {
+    to: felt,
+    selector: felt,
+    calldata_len: felt,
+    calldata: felt*,
+}
+
+// Tmp struct introduced while we wait for Cairo to support passing `[Call]` to __execute__
+struct CallArray {
+    to: felt,
+    selector: felt,
+    data_offset: felt,
+    data_len: felt,
+}
+
+
+@contract_interface
+namespace IAccount {
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+
+    func isValidSignature(hash: felt, signature_len: felt, signature: felt*) -> (isValid: felt) {
+    }
+
+    func __validate__(
+        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+    ) {
+    }
+
+    func __validate_declare__(class_hash: felt) {
+    }
+
+    func __execute__(
+        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+    ) -> (response_len: felt, response: felt*) {
+    }
+}
+
+----
+
+== Keys, signatures and signers
+
+While the interface is agnostic of signature validation schemes, this implementation assumes there's a public-private key pair controlling the Account.
+That's why the `constructor` function expects a `public_key` parameter to set it.
+Since there's also a `setPublicKey()` method, accounts can be effectively transferred.
+
+=== Signature validation
+
+Signature validation occurs separately from execution as of Cairo v0.10.
+Upon receiving transactions, an account contract first calls `\\__validate__`.
+An account will only execute a transaction if, and only if, the signature proves valid.
+This decoupling allows for a protocol-level distinction between invalid and reverted transactions.
+See <<account_entrypoints,Account entrypoints>>.
+
+=== Signer
+
+The signer is responsible for creating a transaction signature with the user's private key for a given transaction.
+This implementation utilizes https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py[Nile's Signer] class to create transaction signatures through the `Signer` method `sign_transaction`.
+
+`sign_transaction` expects the following parameters per transaction:
+
+* `sender` the contract address invoking the tx.
+* `calls` a list containing a sublist of each call to be sent.
+Each sublist must consist of:
+ .. `to` the address of the target contract of the message.
+ .. `selector` the function to be called on the target contract.
+ .. `calldata` the parameters for the given `selector`.
+* `nonce` an unique identifier of this message to prevent transaction replays.
+* `max_fee` the maximum fee a user will pay.
+
+Which returns:
+
+* `calldata` a list of arguments for each call.
+* `sig_r` the transaction signature.
+* `sig_s` the transaction signature.
+
+While the `Signer` class performs much of the work for a transaction to be sent, it neither manages nonces nor invokes the actual transaction on the Account contract.
+To simplify Account management, most of this is abstracted away with `MockSigner`.
+
+=== MockSigner utility
+
+The `MockSigner` class in {test-signers}[signers.py] is used to perform transactions on a given Account, crafting the transaction and managing nonces.
+
+NOTE: StarkNet's testing framework does not currently support transaction invocations from account contracts. `MockSigner` therefore utilizes StarkNet's API gateway to manually execute the `InvokeFunction` for testing.
+
+A `MockSigner` instance exposes the following methods:
+
+* `send_transaction(account, to, selector_name, calldata, nonce=None, max_fee=0)` returns a link:https://docs.python.org/3/library/asyncio-future.html[future] of a signed transaction, ready to be sent.
+* `send_transactions(account, calls, nonce=None, max_fee=0)` returns a future of batched signed transactions, ready to be sent.
+* `declare_class(account, contract_name, nonce=None, max_fee=0)` returns a future of a declaration transaction.
+* `deploy_account(state, calldata, salt=0, nonce=0, max_fee=0)`: returns a future of a counterfactual deployment.
+
+To use `MockSigner`, pass a private key when instantiating the class:
+
+[,python]
+----
+from utils import MockSigner
+
+PRIVATE_KEY = 123456789987654321
+signer = MockSigner(PRIVATE_KEY)
+----
+
+Then send single transactions with the `send_transaction` method.
+
+[,python]
+----
+await signer.send_transaction(account, contract_address, 'method_name', [])
+----
+
+If utilizing multicall, send multiple transactions with the `send_transactions` method.
+
+[,python]
+----
+await signer.send_transactions(
+    account,
+    [
+        (contract_address, 'method_name', [param1, param2]),
+        (contract_address, 'another_method', [])
+    ]
+)
+----
+
+Use `declare_class` to declare a contract:
+
+[,python]
+----
+await signer.declare_class(account, "MyToken")
+----
+
+And `deploy_account` to <<counterfactual_deployments,counterfactually>> deploy an account:
+
+[,python]
+----
+await signer.deploy_account(state, [signer.public_key])
+----
+
+
+=== MockEthSigner utility
+
+The `MockEthSigner` class in {test-signers}[signers.py] is used to perform transactions on a given Account with a secp256k1 curve key pair, crafting the transaction and managing nonces.
+It differs from the `MockSigner` implementation by:
+
+* Not using the public key but its derived address instead (the last 20 bytes of the keccak256 hash of the public key and adding `0x` to the beginning).
+* Signing the message with a secp256k1 curve address.
+
+== `Call` and `AccountCallArray` format
+
+The idea is for all user intent to be encoded into a `Call` representing a smart contract call.
+Users can also pack multiple messages into a single transaction (creating a multicall transaction).
+Cairo currently does not support arrays of structs with pointers which means the `\\__execute__` function cannot properly iterate through multiple ``Call``s.
+Instead, this implementation utilizes a workaround with the `AccountCallArray` struct.
+See <<multicall_transactions,Multicall transactions>>.
+
+=== `Call`
+
+A single `Call` is structured as follows:
+
+[,cairo]
+----
+struct Call {
+    to: felt
+    selector: felt
+    calldata_len: felt
+    calldata: felt*
+}
+----
+
+Where:
+
+* `to` is the address of the target contract of the message.
+* `selector` is the selector of the function to be called on the target contract.
+* `calldata_len` is the number of calldata parameters.
+* `calldata` is an array representing the function parameters.
+
+=== `AccountCallArray`
+
+`AccountCallArray` is structured as:
+
+[,cairo]
+----
+struct AccountCallArray {
+    to: felt
+    selector: felt
+    data_offset: felt
+    data_len: felt
+}
+----
+
+Where:
+
+* `to` is the address of the target contract of the message.
+* `selector` is the selector of the function to be called on the target contract.
+* `data_offset` is the starting position of the calldata array that holds the ``Call``'s calldata.
+* `data_len` is the number of calldata elements in the `Call`.
+
+== Multicall transactions
+
+A multicall transaction packs the `to`, `selector`, `calldata_offset`, and `calldata_len` of each call into the `AccountCallArray` struct and keeps the cumulative calldata for every call in a separate array.
+The `\\__execute__` function rebuilds each message by combining the `AccountCallArray` with its calldata (demarcated by the offset and calldata length specified for that particular call).
+The rebuilding logic is set in the internal `_from_call_array_to_call`.
+
+This is the basic flow:
+
+First, the user sends the messages for the transaction through a Signer instantiation which looks like this:
+
+[,python]
+----
+await signer.send_transaction(
+    account, [
+        (contract_address, 'contract_method', [arg_1]),
+        (contract_address, 'another_method', [arg_1, arg_2])
+    ]
+)
+----
+
+Then the `from_call_to_call_array` method in link:https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py[Nile's signer] converts each call into the `AccountCallArray` format and cumulatively stores the calldata of every call into a single array.
+Next, both arrays (as well as the `sender`, `nonce`, and `max_fee`) are used to create the transaction hash.
+The Signer then invokes `\__execute__` with the signature and passes `AccountCallArray`, calldata, and nonce as arguments.
+
+Finally, the `\\__execute__` method takes the `AccountCallArray` and calldata and builds an array of ``Call``s (MultiCall).
+
+NOTE: Every transaction utilizes `AccountCallArray`.
+A single `Call` is treated as a bundle with one message.
+
+== API Specification
+
+This in a nutshell is the Account contract public API:
+
+[,cairo]
+----
+namespace Account {
+    func constructor(publicKey: felt) {
+    }
+
+    func getPublicKey() -> (publicKey: felt) {
+    }
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+
+    func setPublicKey(newPublicKey: felt) {
+    }
+
+    func isValidSignature(hash: felt, signature_len: felt, signature: felt*) -> (isValid: felt) {
+    }
+
+    func __validate__(
+        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+    ) -> (response_len: felt, response: felt*) {
+    }
+
+    func __validate_declare__(
+        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+    ) -> (response_len: felt, response: felt*) {
+    }
+
+    func __execute__(
+        call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*
+    ) -> (response_len: felt, response: felt*) {
+}
+----
+
+=== `constructor`
+
+Initializes and sets the public key for the Account contract.
+
+Parameters:
+
+[,cairo]
+----
+publicKey: felt
+----
+
+Returns: None.
+
+=== `getPublicKey`
+
+Returns the public key associated with the Account.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+publicKey: felt
+----
+
+=== `supportsInterface`
+
+Returns `TRUE` if this contract implements the interface defined by `interfaceId`.
+Account contracts now implement ERC165 through static support (see <<account_introspection_with_erc165,Account introspection with ERC165>>).
+
+Parameters:
+
+[,cairo]
+----
+interfaceId: felt
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+=== `setPublicKey`
+
+Sets the public key that will control this Account.
+It can be used to rotate keys for security, change them in case of compromised keys or even transferring ownership of the account.
+
+Parameters:
+
+[,cairo]
+----
+newPublicKey: felt
+----
+
+Returns: None.
+
+=== `isValidSignature`
+
+This function is inspired by https://eips.ethereum.org/EIPS/eip-1271[EIP-1271] and returns `TRUE` if a given signature is valid, otherwise it reverts.
+In the future it will return `FALSE` if a given signature is invalid (for more info please check https://github.com/OpenZeppelin/cairo-contracts/issues/327[this issue]).
+
+Parameters:
+
+[,cairo]
+----
+hash: felt
+signature_len: felt
+signature: felt*
+----
+
+Returns:
+
+[,cairo]
+----
+isValid: felt
+----
+
+NOTE: It may return `FALSE` in the future if a given signature is invalid (follow the discussion on https://github.com/OpenZeppelin/cairo-contracts/issues/327[this issue]).
+
+=== `\\__validate__`
+
+Validates the transaction signature and is called prior to `\\__execute__`.
+
+Parameters:
+
+[,cairo]
+----
+call_array_len: felt
+call_array: AccountCallArray*
+calldata_len: felt
+calldata: felt*
+----
+
+Returns: None.
+
+=== `\\__validate_declare__`
+
+Validates the signature for declaration transactions.
+
+Parameters:
+
+[,cairo]
+----
+class_hash: felt
+----
+
+Returns: None.
+
+=== `\\__validate_deploy__`
+
+Validates the signature for counterfactual deployment transactions.
+
+It takes the `class_hash` of the account being deployed along with the `salt` and `calldata`, the latter being expanded. For example if the account is deployed with calldata `[arg_1, ..., arg_n]`:
+
+Parameters:
+
+[,cairo]
+----
+class_hash: felt
+salt: felt
+arg_1: felt
+...
+arg_n: felt
+----
+
+Returns: None.
+
+=== `\\__execute__`
+
+This is the only external entrypoint to interact with the Account contract.
+It:
+
+. Calls the target contract with the intended function selector and calldata parameters.
+. Forwards the contract call response data as return value.
+
+Parameters:
+
+[,cairo]
+----
+call_array_len: felt
+call_array: AccountCallArray*
+calldata_len: felt
+calldata: felt*
+----
+
+NOTE: The current signature scheme expects a 2-element array like `[sig_r, sig_s]`.
+
+Returns:
+
+[,cairo]
+----
+response_len: felt
+response: felt*
+----
+
+== Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing.
+Each preset differs on the signature type being used by the Account.
+
+=== Account
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/account/presets/Account.cairo[`Account`] preset uses StarkNet keys to validate transactions.
+
+=== Eth Account
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/account/presets/EthAccount.cairo[`EthAccount`] preset supports Ethereum addresses, validating transactions with secp256k1 keys.
+
+== Account introspection with ERC165
+
+Certain contracts like ERC721 or ERC1155 require a means to differentiate between account contracts and non-account contracts.
+For a contract to declare itself as an account, it should implement https://eips.ethereum.org/EIPS/eip-165[ERC165] as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
+
+To be in compliance with ERC165 specifications, we calculate the account contract ID as the XOR of ``IAccount``'s equivalent EVM selectors (not StarkNet selectors).
+This magic value has been tracking the changes of the still evolving Account interface standard, and **its current value is `0xa66bd575`**.
+
+Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implementation of https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage[ERC165Storage] which stores the interfaces that the implementing contract supports.
+In the case of account contracts, querying `supportsInterface` of an account's address with the `IAccount` magic value should return `TRUE`.
+
+NOTE: For Account contracts, ERC165 support is static and does not require Account contracts to register.
+
+== Extending the Account contract
+
+Account contracts can be extended by following the xref:extensibility.adoc#the_pattern[extensibility pattern].
+
+To implement custom account contracts, it's required by the StarkNet compiler that they include the three entrypoint functions `\\__validate__`, `\\__validate_declare__`, and `\\__execute__`.
+
+`\\__validate__` and `\\__validate_declare__` should include the same signature validation method; whereas, `\\__execute__` should only handle the actual transaction. Incorporating a new validation scheme necessitates only that it's invoked by both `\\__validate__` and `\\__validate_declare__`.
+
+This is why the Account library comes with different flavors of signature validation methods like `is_valid_eth_signature` and the vanilla `is_valid_signature`.
+
+Account contract developers are encouraged to implement the https://github.com/OpenZeppelin/cairo-contracts/discussions/41[standard Account interface] and incorporate the custom logic thereafter.
+
+IMPORTANT: Due to current inconsistencies between the testing framework and the actual StarkNet network, extreme caution should be used when integrating new Account contracts.
+Instances have occurred where account functionality tests pass and transactions execute correctly on the local node; yet, they fail on public networks.
+For this reason, it's highly encouraged that new account contracts are also deployed and tested on the public testnet.
+See https://github.com/OpenZeppelin/cairo-contracts/issues/386[issue #386] for more information.
+
+Some other validation schemes to look out for in the future:
+
+* Multisig.
+* Guardian logic like in https://github.com/argentlabs/argent-contracts-starknet/blob/de5654555309fa76160ba3d7393d32d2b12e7349/contracts/ArgentAccount.cairo[Argent's account].
+
+== L1 escape hatch mechanism
+
+[unknown, to be defined]
+
+== Paying for gas
+
+[unknown, to be defined]

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc1155.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc1155.adoc
@@ -1,0 +1,548 @@
+= ERC1155
+
+The ERC1155 multi token standard is a specification for https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens[fungibility-agnostic] token contracts.
+The ERC1155 library implements an approximation of https://eips.ethereum.org/EIPS/eip-1155[EIP-1155] in Cairo for StarkNet.
+
+== Table of Contents
+
+* <<ierc1155,IERC1155>>
+* <<erc1155_compatibility,ERC1155 Compatibility>>
+* <<usage,Usage>>
+ ** <<token_transfers,Token Transfers>>
+ ** <<interpreting_erc1155_uris,Interpreting ERC1155 URIs>>
+ ** <<erc1155received,ERC1155Received>>
+* <<presets,Presets>>
+* <<utilities,Utilities>>
+ ** <<erc1155holder,ERC1155Holder>>
+* <<api_specification,API Specification>>
+ ** <<ierc1155_api,`IERC1155`>>
+ ** <<events,Events>>
+ ** <<ierc1155metadata_api,`IERC1155Metadata`>>
+ ** <<ierc1155receiver_api,`IERC1155Receiver`>>
+
+== IERC1155
+
+[,cairo]
+----
+@contract_interface
+namespace IERC1155 {
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(
+        accounts_len: felt,
+        accounts: felt*,
+        ids_len: felt,
+         ids: Uint256*
+    ) -> (
+        balances_len: felt,
+        balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(
+        account: felt,
+        operator: felt
+    ) -> (approved: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt,
+        to: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    --------------- IERC165 ---------------
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}
+----
+
+=== ERC1155 Compatibility
+
+Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC1155 standard in the following ways:
+
+* It uses Cairo's `uint256` instead of `felt`.
+* It returns `TRUE` as success.
+
+But some differences can still be found, such as:
+
+* It implements an `uri()` function that returns the same URI for *all* token types. It relies on the token type ID substitution mechanism https://eips.ethereum.org/EIPS/eip-1155#metadata[defined in the EIP]. Clients calling this function must replace the `\{id\}` substring with the actual token type ID.
+* `safeTransferFrom` and `safeBatchTransferFrom` are specified such that the optional `data` argument should be of type bytes.
+In Solidity, this means a dynamically-sized array.
+To be as close as possible to the standard, the `data` argument accepts a dynamic array of felts.
+In Cairo, arrays are expressed with the array length preceding the actual array;
+hence, the method accepts `data_len` and `data` respectively as types `felt` and `felt*`.
+* `IERC1155Receiver` compliant contracts (`ERC1155Holder`) return a hardcoded selector id according to EVM selectors, since selectors are calculated differently in Cairo.
+This is in line with the ERC165 interfaces design choice towards EVM compatibility.
+See the xref:introspection.adoc[Introspection docs] for more info.
+* `IERC1155Receiver` compliant contracts (`ERC1155Holder`) must support ERC165 by registering the `IERC1155Receiver` selector id in its constructor and exposing the `supportsInterface` method.
+In doing so, recipient contracts (both accounts and non-accounts) can be verified that they support ERC1155 transfers.
+
+== Usage
+
+To show a standard use case, we'll use the `ERC1155MintableBurnable` preset which allows for only the owner to `mint` tokens.
+To create a token, you need to first deploy both Account and ERC1155 contracts respectively.
+
+Considering that the ERC1155 constructor method looks like this:
+
+[,cairo]
+----
+func constructor(
+    uri: felt,      // Token URI as Cairo short string
+    owner: felt     // Address designated as the contract owner
+) {
+}
+----
+
+Deployment of both contracts looks like this:
+
+[,python]
+----
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+erc1155 = await starknet.deploy(
+    "contracts/token/erc1155/presets/ERC1155MintableBurnable.cairo",
+    constructor_calldata=[
+        str_to_felt("http://my.uri/{id}"),        # uri
+        account.contract_address                  # owner
+    ]
+)
+----
+
+To mint tokens, send a transaction like this:
+
+[,python]
+----
+signer = MockSigner(PRIVATE_KEY)
+token_id = uint(1)
+mint_value = uint(1000)
+
+await signer.send_transaction(
+    account, erc1155.contract_address, 'mint', [
+        recipient_address,
+        *token_id,
+        *mint_value,
+        0 # data
+    ]
+)
+----
+
+=== Token Transfers
+
+This library includes `safeTransferFrom` and `safeBatchTransferFrom` to transfer assets. These methods incorporate the following conditional logic:
+
+. If the receiving address xref:accounts.adoc#account_introspection_with_erc165[is identified as an account], the tokens will be transferred.
+. If the receiving address is not an account contract, the function will check that the receiver supports ERC1155 tokens before sending them.
+
+The current implementation requires recipient contracts to support ERC165 and expose the `supportsInterface` method.
+See <<erc1155received,ERC1155Received>>.
+
+=== Interpreting ERC1155 URIs
+
+Token URIs in Cairo are stored as single field elements.
+Each field element equates to 252-bits (or  31.5 bytes) which means that a token's URI can be no longer than 31 characters.
+
+NOTE: Storing the URI as an array of felts was considered to accommodate larger strings.
+While this approach is more flexible regarding URIs, a returned array further deviates from the standard. Therefore, this library's ERC1155 implementation sets URIs as a single field element.
+
+The `utils.py` module includes utility methods for converting to/from Cairo field elements.
+To properly interpret a URI from ERC1155, simply trim the null bytes and decode the remaining bits as an ASCII string.
+For example:
+
+[,python]
+----
+# HELPER METHODS
+def str_to_felt(text):
+    b_text = bytes(text, 'ascii')
+    return int.from_bytes(b_text, "big")
+
+def felt_to_str(felt):
+    b_felt = felt.to_bytes(31, "big")
+    return b_felt.decode()
+
+token_id = uint(1)
+sample_uri = str_to_felt('mock://mytoken')
+
+await signer.send_transaction(
+    account, erc1155.contract_address, 'setTokenURI', [
+        *token_id, sample_uri]
+)
+
+felt_uri = await erc1155.tokenURI(first_token_id).call()
+string_uri = felt_to_str(felt_uri)
+----
+
+=== ERC1155Received
+
+In order to be sure a contract can safely accept ERC1155 tokens, said contract must implement the <<ierc1155receiver_api,`IERC1155Receiver`>> interface (as expressed in the EIP1155 specification).
+Methods such as `safeTransferFrom` and `safeBatchTransferFrom` call the recipient contract's `onERC1155Received` or `onERC1155BatchReceived` method.
+If the contract fails to return the correct magic value, the transaction fails.
+
+StarkNet contracts that support safe transfers, however, must also support xref:introspection.adoc#erc165[ERC165] and include `supportsInterface` as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
+Transfer functions require a means of differentiating between account and non-account contracts.
+Currently, StarkNet does not support error handling from the contract level;
+therefore, the current ERC1155 implementation requires that all contracts that support safe ERC1155 transfers (both accounts and non-accounts) include the `supportsInterface` method.
+Further, `supportsInterface` should return `TRUE` if the recipient contract supports the `IERC1155Receiver` magic value `00x4e2312e0` (which invokes `onERC1155Received` and `onERC1155BatchReceived`).
+If the recipient contract supports the `IAccount` magic value, `supportsInterface` should return `TRUE`.
+Otherwise, transfer functions should fail.
+
+== Presets
+
+=== ERC1155MintableBurnable
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc1155/presets/ERC1155MintableBurnable.cairo[`ERC1155MintableBurnable`] preset offers a quick and easy setup for creating ERC1155 tokens. Its constructor takes three arguments: `name`, `symbol`, and an `owner` address which will be capable of minting tokens.
+
+== Utilities
+
+=== ERC1155Holder
+
+Implementation of the `IERC1155Receiver` interface.
+
+Accepts all token transfers.
+Make sure the contract is able to use its token with `IERC1155.safeTransferFrom`, `IERC1155.approve` or `IERC1155.setApprovalForAll`.
+
+Also utilizes the ERC165 method `supportsInterface` to determine if the contract is an account.
+See <<erc1155received,ERC1155Received>>.
+
+== API Specification
+
+=== IERC1155 API
+
+[,cairo]
+----
+func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+}
+
+func balanceOfBatch(
+    accounts_len: felt,
+    accounts: felt*,
+    ids_len: felt,
+    ids: Uint256*
+) -> (
+    balances_len: felt,
+    balances: Uint256*
+) {
+}
+
+func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+}
+
+func setApprovalForAll(operator: felt, approved: felt) {
+}
+
+func safeTransferFrom(
+    from_: felt,
+    to: felt,
+    id: Uint256,
+    value: Uint256,
+    data_len: felt,
+    data: felt*
+) {
+}
+
+func safeBatchTransferFrom(
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+}
+----
+
+==== `balanceOf`
+
+Returns the number of `id` tokens of ``account``.
+
+Parameters:
+
+[,cairo]
+----
+account: felt
+id: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+balance: Uint256
+----
+
+==== `balanceOfBatch`
+
+Get the balance of multiple account/token pairs.
+
+Parameters:
+
+[,cairo]
+----
+accounts_len: felt
+accounts: felt*
+ids_len: felt
+ids: Uint156*
+----
+
+Returns:
+
+[,cairo]
+----
+balances_len: felt
+balances: Uint256*
+----
+
+==== `isApprovedForAll`
+
+Get whether `operator` is approved by `account` for all tokens.
+
+Parameters:
+
+[,cairo]
+----
+account: felt
+operator: felt
+----
+
+Returns:
+
+[,cairo]
+----
+approved: felt
+----
+
+==== `setApprovalForAll`
+
+Enable or disable approval for a third party ("operator") to manage all of the caller's tokens.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+approved: felt
+----
+
+Returns: None.
+
+==== `safeTransferFrom`
+
+Transfers `value` amount of token `id` from `from_` to `to`, checking first that contract recipients are aware and capable of handling ERC1155 tokens to prevent locking them forever.
+For information regarding how contracts communicate their awareness of the ERC1155 protocol, see <<erc1155received,ERC1155Received>>.
+
+Emits a <<transfersingle_event,TransferSingle>> event.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+id: Uint256
+value: Uint256
+data_len: felt
+data: felt*
+----
+
+Returns: None.
+
+==== `safeBatchTransferFrom`
+
+Batch version of <<safetransferfrom,`safeTransferFrom`>>. Emits a <<transferbatch_event,TransferBatch>> event.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+ids_len: felt
+ids: Uint256*
+values_len: felt
+values: Uint256*
+data_len: felt
+data: felt*
+----
+
+Returns: None.
+
+'''
+
+=== Events
+
+==== `TransferSingle (Event)`
+
+Emitted when `operator` sends `value` amount of `id` token from `from_` to `to`.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+from_: felt
+to: felt
+id: Uint256
+value: Uint256
+----
+
+==== `TransferBatch (Event)`
+
+Emitted when `operator` sends multiple `values` of multiple token `ids` from `from_` to `to`.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+from_: felt
+to: felt
+ids_len: felt
+ids: Uint256*
+values_len: felt
+values: Uint256*
+----
+
+==== `ApprovalForAll (Event)`
+
+Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+
+Parameters:
+
+[,cairo]
+----
+account: felt
+operator: felt
+approved: felt
+----
+
+'''
+
+=== IERC1155Metadata API
+
+[,cairo]
+----
+func uri(id: Uint256) -> (uri: felt) {
+}
+----
+
+==== `uri`
+
+Returns the Uniform Resource Identifier (URI) for a token `id`, although this implementation returns the same URI for *all* token types. It relies
+on the token type ID substitution mechanism
+https://eips.ethereum.org/EIPS/eip-1155#metadata[defined in the EIP].
+
+Parameters:
+
+[,cairo]
+----
+id: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+uri: felt
+----
+
+'''
+
+=== IERC1155Receiver API
+
+[,cairo]
+----
+func onERC1155Received(
+    operator: felt,
+    from_: felt,
+    tokenId: Uint256,
+    data_len: felt,
+    data: felt*
+) -> (selector: felt) {
+}
+
+func onERC1155BatchReceived(
+    operator: felt,
+    from_: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) -> (selector: felt) {
+}
+----
+
+==== `onERC1155Received`
+
+Whenever any IERC1155 token is transferred or minted to this non-account contract by `operator` from `from_`, this function is called.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+from_: felt
+id: Uint256
+value: Uint156
+data_len: felt
+data: felt*
+----
+
+Returns:
+
+[,cairo]
+----
+selector: felt
+----
+
+==== `onERC1155BatchReceived`
+
+Whenever any IERC1155 token is transferred to this non-account contract via `safeBatchTransferFrom` by `operator` from `from_`, this function is called.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+from_: felt
+ids_len: felt
+ids: Uint256*
+values_len: felt
+values: Uint156*
+data_len: felt
+data: felt*
+----
+
+Returns:
+
+[,cairo]
+----
+selector: felt
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc20.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc20.adoc
@@ -1,0 +1,420 @@
+= ERC20
+
+The ERC20 token standard is a specification for https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens[fungible tokens], a type of token where all the units are exactly equal to each other.
+The `ERC20.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-20[EIP-20] in Cairo for StarkNet.
+
+== Table of Contents
+
+* <<interface,Interface>>
+ ** <<erc20_compatibility,ERC20 compatibility>>
+* <<usage,Usage>>
+* <<extensibility,Extensibility>>
+* <<presets,Presets>>
+ ** <<erc20_basic,ERC20 (basic)>>
+ ** <<erc20mintable,ERC20Mintable>>
+ ** <<erc20pausable,ERC20Pausable>>
+ ** <<erc20upgradeable,ERC20Upgradeable>>
+* <<api_specification,API Specification>>
+ ** <<methods,Methods>>
+  *** <<name,`name`>>
+  *** <<symbol,`symbol`>>
+  *** <<decimals,`decimals`>>
+  *** <<totalsupply,`totalSupply`>>
+  *** <<balanceof,`balanceOf`>>
+  *** <<allowance,`allowance`>>
+  *** <<transfer,`transfer`>>
+  *** <<transferfrom,`transferFrom`>>
+  *** <<approve,`approve`>>
+ ** <<events,Events>>
+  *** <<transfer_event,`Transfer (event)`>>
+  *** <<approval_event,`Approval (event)`>>
+
+== Interface
+
+[,cairo]
+----
+@contract_interface
+namespace IERC20 {
+    func name() -> (name: felt) {
+    }
+
+    func symbol() -> (symbol: felt) {
+    }
+
+    func decimals() -> (decimals: felt) {
+    }
+
+    func totalSupply() -> (totalSupply: Uint256) {
+    }
+
+    func balanceOf(account: felt) -> (balance: Uint256) {
+    }
+
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256) {
+    }
+
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func transferFrom(sender: felt, recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func approve(spender: felt, amount: Uint256) -> (success: felt) {
+    }
+}
+----
+
+=== ERC20 compatibility
+
+Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
+
+* It uses Cairo's `uint256` instead of `felt`.
+* It returns `TRUE` as success.
+* It accepts a `felt` argument for `decimals` in the constructor calldata with a max value of 2{caret}8 (imitating `uint8` type).
+* It makes use of Cairo's short strings to simulate `name` and `symbol`.
+
+But some differences can still be found, such as:
+
+* `transfer`, `transferFrom` and `approve` will never return anything different from `TRUE` because they will revert on any error.
+* Function selectors are calculated differently between https://github.com/starkware-libs/cairo-lang/blob/7712b21fc3b1cb02321a58d0c0579f5370147a8b/src/starkware/starknet/public/abi.py#L25[Cairo] and https://solidity-by-example.org/function-selector/[Solidity].
+
+== Usage
+
+Use cases go from medium of exchange currency to voting rights, staking, and more.
+
+Considering that the constructor method looks like this:
+
+[,cairo]
+----
+func constructor(
+    name: felt,               // Token name as Cairo short string
+    symbol: felt,             // Token symbol as Cairo short string
+    decimals: felt            // Token decimals (usually 18)
+    initial_supply: Uint256,  // Amount to be minted
+    recipient: felt           // Address where to send initial supply to
+) {
+}
+----
+
+To create a token you need to deploy it like this:
+
+[,python]
+----
+erc20 = await starknet.deploy(
+    "openzeppelin/token/erc20/presets/ERC20.cairo",
+    constructor_calldata=[
+        str_to_felt("Token"),     # name
+        str_to_felt("TKN"),       # symbol
+        18,                       # decimals
+        (1000, 0),                # initial supply
+        account.contract_address  # recipient
+    ]
+)
+----
+
+As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
+This is why we need an Account contract to interact with it.
+For example:
+
+[,python]
+----
+signer = MockSigner(PRIVATE_KEY)
+amount = uint(100)
+
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+await signer.send_transaction(account, erc20.contract_address, 'transfer', [recipient_address, *amount])
+----
+
+== Extensibility
+
+ERC20 contracts can be extended by following the xref:extensibility.adoc#the_pattern[extensibility pattern].
+The basic idea behind integrating the pattern is to import the requisite ERC20 methods from the ERC20 library and incorporate the extended logic thereafter.
+For example, let's say you wanted to implement a pausing mechanism.
+The contract should first import the ERC20 methods and the extended logic from the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/security/pausable/library.cairo[Pausable library] i.e. `Pausable.pause`, `Pausable.unpause`.
+Next, the contract should expose the methods with the extended logic therein like this:
+
+[,cairo]
+----
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();                 // imported extended logic
+    return ERC20.transfer(recipient, amount);     // imported library method
+}
+----
+
+Note that extensibility does not have to be only library-based like in the above example.
+For instance, an ERC20 contract with a pausing mechanism can define the pausing methods directly in the contract or even import the `pausable` methods from the library and tailor them further.
+
+Some other ways to extend ERC20 contracts may include:
+
+* Implementing a minting mechanism.
+* Creating a timelock.
+* Adding roles such as owner or minter.
+
+For full examples of the extensibility pattern being used in ERC20 contracts, see <<presets,Presets>>.
+
+== Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing.
+Each preset mints an initial supply which is especially necessary for presets that do not expose a `mint` method.
+
+=== ERC20 (basic)
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20.cairo[`ERC20`] preset offers a quick and easy setup for deploying a basic ERC20 token.
+
+=== ERC20Mintable
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo[`ERC20Mintable`] preset allows the contract owner to mint new tokens.
+
+=== ERC20Pausable
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo[`ERC20Pausable`] preset allows the contract owner to pause/unpause all state-modifying methods i.e.
+`transfer`, `approve`, etc.
+This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
+
+=== ERC20Upgradeable
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo[`ERC20Upgradeable`] preset allows the contract owner to upgrade a contract by deploying a new ERC20 implementation contract while also maintaining the contract's state.
+This preset proves useful for scenarios such as eliminating bugs and adding new features.
+For more on upgradeability, see xref:proxies.adoc#contract_upgrades[Contract upgrades].
+
+== API Specification
+
+=== Methods
+
+[,cairo]
+----
+func name() -> (name: felt) {
+}
+
+func symbol() -> (symbol: felt) {
+}
+
+func decimals() -> (decimals: felt) {
+}
+
+func totalSupply() -> (totalSupply: Uint256) {
+}
+
+func balanceOf(account: felt) -> (balance: Uint256) {
+}
+
+func allowance(owner: felt, spender: felt) -> (remaining: Uint256) {
+}
+
+func transfer(recipient: felt, amount: Uint256) -> (success: felt) {
+}
+
+func transferFrom(sender: felt, recipient: felt, amount: Uint256) -> (success: felt) {
+}
+
+func approve(spender: felt, amount: Uint256) -> (success: felt) {
+}
+----
+
+==== `name`
+
+Returns the name of the token.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+name: felt
+----
+
+==== `symbol`
+
+Returns the ticker symbol of the token.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+symbol: felt
+----
+
+==== `decimals`
+
+Returns the number of decimals the token uses - e.g.
+`8` means to divide the token amount by `100000000` to get its user representation.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+decimals: felt
+----
+
+==== `totalSupply`
+
+Returns the amount of tokens in existence.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+totalSupply: Uint256
+----
+
+==== `balanceOf`
+
+Returns the amount of tokens owned by `account`.
+
+Parameters:
+
+[,cairo]
+----
+account: felt
+----
+
+Returns:
+
+[,cairo]
+----
+balance: Uint256
+----
+
+==== `allowance`
+
+Returns the remaining number of tokens that `spender` will be allowed to spend on behalf of `owner` through `transferFrom`.
+This is zero by default.
+
+This value changes when `approve` or `transferFrom` are called.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+spender: felt
+----
+
+Returns:
+
+[,cairo]
+----
+remaining: Uint256
+----
+
+==== `transfer`
+
+Moves `amount` tokens from the caller's account to `recipient`.
+It returns `1` representing a bool if it succeeds.
+
+Emits a <<transfer_event,Transfer>> event.
+
+Parameters:
+
+[,cairo]
+----
+recipient: felt
+amount: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+==== `transferFrom`
+
+Moves `amount` tokens from `sender` to `recipient` using the allowance mechanism.
+`amount` is then deducted from the caller's allowance.
+It returns `1` representing a bool if it succeeds.
+
+Emits a <<transfer_event,Transfer>> event.
+
+Parameters:
+
+[,cairo]
+----
+sender: felt
+recipient: felt
+amount: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+==== `approve`
+
+Sets `amount` as the allowance of `spender` over the caller's tokens.
+It returns `1` representing a bool if it succeeds.
+
+Emits an <<approval_event,Approval>> event.
+
+Parameters:
+
+[,cairo]
+----
+spender: felt
+amount: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+=== Events
+
+[,cairo]
+----
+func Transfer(from_: felt, to: felt, value: Uint256) {
+}
+
+func Approval(owner: felt, spender: felt, value: Uint256) {
+}
+----
+
+==== `Transfer (event)`
+
+Emitted when `value` tokens are moved from one account (`from_`) to another (`to`).
+
+Note that `value` may be zero.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+value: Uint256
+----
+
+==== `Approval (event)`
+
+Emitted when the allowance of a `spender` for an `owner` is set by a call to <<approve,approve>>.
+`value` is the new allowance.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+spender: felt
+value: Uint256
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc721.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/erc721.adoc
@@ -1,0 +1,772 @@
+= ERC721
+
+The ERC721 token standard is a specification for https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens[non-fungible tokens], or more colloquially: NFTs.
+The `ERC721.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-721[EIP-721] in Cairo for StarkNet.
+
+== Table of Contents
+
+* <<ierc721,IERC721>>
+* <<erc721_compatibility,ERC721 Compatibility>>
+* <<usage,Usage>>
+ ** <<token_transfers,Token Transfers>>
+ ** <<interpreting_erc721_uris,Interpreting ERC721 URIs>>
+ ** <<erc721received,ERC721Received>>
+  *** <<ierc721receiver,IERC721Receiver>>
+ ** <<supporting_interfaces,Supporting Interfaces>>
+ ** <<ready_to_use_presets,Ready_to_Use Presets>>
+* <<extensibility,Extensibility>>
+* <<presets,Presets>>
+ ** <<erc721mintableburnable,ERC721MintableBurnable>>
+ ** <<erc721mintablepausable,ERC721MintablePausable>>
+ ** <<erc721enumerablemintableburnable,ERC721EnumerableMintableBurnable>>
+  *** <<ierc721enumerable,IERC721Enumerable>>
+ ** <<erc721metadata,ERC721Metadata>>
+  *** <<ierc721metadata,IERC721Metadata>>
+* <<utilities,Utilities>>
+ ** <<erc721_holder,ERC721Holder>>
+* <<api_specification,API Specification>>
+ ** <<ierc721_api,`IERC721`>>
+  *** <<balanceof,`balanceOf`>>
+  *** <<ownerof,`ownerOf`>>
+  *** <<safetransferfrom,`safeTransferFrom`>>
+  *** <<transferfrom,`transferFrom`>>
+  *** <<approve,`approve`>>
+  *** <<setapprovalforall,`setApprovalForAll`>>
+  *** <<getapproved,`getApproved`>>
+  *** <<isapprovedforall,`isApprovedForAll`>>
+ ** <<events,Events>>
+  *** <<approval_event,`Approval (event)`>>
+  *** <<approvalforall_event,`ApprovalForAll (event)`>>
+  *** <<transfer_event,`Transfer (event)`>>
+ ** <<ierc721metadata,`IERC721Metadata`>>
+  *** <<name,`name`>>
+  *** <<symbol,`symbol`>>
+  *** <<tokenuri,`tokenURI`>>
+ ** <<ierc721enumerable,`IERC721Enumerable`>>
+  *** <<totalsupply,`totalSupply`>>
+  *** <<tokenbyindex,`tokenByIndex`>>
+  *** <<tokenofownerbyindex,`tokenOfOwnerByIndex`>>
+ ** <<ierc721receiver_api,`IERC721Receiver`>>
+  *** <<onerc721received,`onERC721Received`>>
+
+== IERC721
+
+[,cairo]
+----
+@contract_interface
+namespace IERC721 {
+    func balanceOf(owner: felt) -> (balance: Uint256) {
+    }
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt) {
+    }
+
+    func safeTransferFrom(from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*) {
+    }
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256) {
+    }
+
+    func approve(approved: felt, tokenId: Uint256) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func getApproved(tokenId: Uint256) -> (approved: felt) {
+    }
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (approved: felt) {
+    }
+
+    --------------- IERC165 ---------------
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}
+----
+
+=== ERC721 Compatibility
+
+Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC721 standard in the following ways:
+
+* It uses Cairo's `uint256` instead of `felt`.
+* It returns `TRUE` as success.
+* It makes use of Cairo's short strings to simulate `name` and `symbol`.
+
+But some differences can still be found, such as:
+
+* `tokenURI` returns a felt representation of the queried token's URI.
+The EIP721 standard, however, states that the return value should be of type string.
+If a token's URI is not set, the returned value is `0`.
+Note that URIs cannot exceed 31 characters.
+See <<interpreting_erc721_uris,Interpreting ERC721 URIs>>.
+* ``interface_id``s are hardcoded and initialized by the constructor.
+The hardcoded values derive from Solidity's selector calculations.
+See <<supporting_interfaces,Supporting Interfaces>>.
+* `safeTransferFrom` can only be expressed as a single function in Cairo as opposed to the two functions declared in EIP721.
+The difference between both functions consists of accepting `data` as an argument.
+Because function overloading is currently not possible in Cairo, `safeTransferFrom` by default accepts the `data` argument.
+If `data` is not used, simply insert `0`.
+* `safeTransferFrom` is specified such that the optional `data` argument should be of type bytes.
+In Solidity, this means a dynamically-sized array.
+To be as close as possible to the standard, it accepts a dynamic array of felts.
+In Cairo, arrays are expressed with the array length preceding the actual array;
+hence, the method accepts `data_len` and `data` respectively as types `felt` and `felt*`.
+* `ERC165.register_interface` allows contracts to set and communicate which interfaces they support.
+This follows OpenZeppelin's https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v0.6.1/contracts/utils/introspection/ERC165Storage.sol[ERC165Storage].
+* `IERC721Receiver` compliant contracts (`ERC721Holder`) return a hardcoded selector id according to EVM selectors, since selectors are calculated differently in Cairo.
+This is in line with the ERC165 interfaces design choice towards EVM compatibility.
+See the xref:introspection.adoc[Introspection docs] for more info.
+* `IERC721Receiver` compliant contracts (`ERC721Holder`) must support ERC165 by registering the `IERC721Receiver` selector id in its constructor and exposing the `supportsInterface` method.
+In doing so, recipient contracts (both accounts and non-accounts) can be verified that they support ERC721 transfers.
+* `ERC721Enumerable` tracks the total number of tokens with the `all_tokens` and `all_tokens_len` storage variables mimicking the array of the Solidity implementation.
+
+== Usage
+
+Use cases go from artwork, digital collectibles, physical property, and many more.
+
+To show a standard use case, we'll use the `ERC721Mintable` preset which allows for only the owner to `mint` and `burn` tokens.
+To create a token you need to first deploy both Account and ERC721 contracts respectively.
+As most StarkNet contracts, ERC721 expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
+This is why we need an Account contract to interact with it.
+
+Considering that the ERC721 constructor method looks like this:
+
+[,cairo]
+----
+func constructor(
+    name: felt,          // Token name as Cairo short string
+    symbol: felt,        // Token symbol as Cairo short string
+    owner: felt          // Address designated as the contract owner
+) {
+}
+----
+
+Deployment of both contracts looks like this:
+
+[,python]
+----
+account = await starknet.deploy(
+    "contracts/Account.cairo",
+    constructor_calldata=[signer.public_key]
+)
+
+erc721 = await starknet.deploy(
+    "contracts/token/erc721/presets/ERC721Mintable.cairo",
+    constructor_calldata=[
+        str_to_felt("Token"),                       # name
+        str_to_felt("TKN"),                         # symbol
+        account.contract_address                    # owner
+    ]
+)
+----
+
+To mint a non-fungible token, send a transaction like this:
+
+[,python]
+----
+signer = MockSigner(PRIVATE_KEY)
+tokenId = uint(1)
+
+await signer.send_transaction(
+    account, erc721.contract_address, 'mint', [
+        recipient_address,
+        *tokenId
+    ]
+)
+----
+
+=== Token Transfers
+
+This library includes `transferFrom` and `safeTransferFrom` to transfer NFTs.
+If using `transferFrom`, *the caller is responsible to confirm that the recipient is capable of receiving NFTs or else they may be permanently lost.*
+
+The `safeTransferFrom` method incorporates the following conditional logic:
+
+. if the calling address is an account contract, the token transfer will behave as if `transferFrom` was called
+. if the calling address is not an account contract, the safe function will check that the contract supports ERC721 tokens
+
+The current implementation of `safeTansferFrom` checks for `onERC721Received` and requires that the recipient contract supports ERC165 and exposes the `supportsInterface` method.
+See <<erc721received,ERC721Received>>.
+
+=== Interpreting ERC721 URIs
+
+Token URIs in Cairo are stored as single field elements.
+Each field element equates to 252-bits (or  31.5 bytes) which means that a token's URI can be no longer than 31 characters.
+
+NOTE: Storing the URI as an array of felts was considered to accommodate larger strings.
+While this approach is more flexible regarding URIs, a returned array further deviates from the standard set in https://eips.ethereum.org/EIPS/eip-721[EIP721].
+Therefore, this library's ERC721 implementation sets URIs as a single field element.
+
+The `utils.py` module includes utility methods for converting to/from Cairo field elements.
+To properly interpret a URI from ERC721, simply trim the null bytes and decode the remaining bits as an ASCII string.
+For example:
+
+[,python]
+----
+# HELPER METHODS
+def str_to_felt(text):
+    b_text = bytes(text, 'ascii')
+    return int.from_bytes(b_text, "big")
+
+def felt_to_str(felt):
+    b_felt = felt.to_bytes(31, "big")
+    return b_felt.decode()
+
+token_id = uint(1)
+sample_uri = str_to_felt('mock://mytoken')
+
+await signer.send_transaction(
+    account, erc721.contract_address, 'setTokenURI', [
+        *token_id, sample_uri]
+)
+
+felt_uri = await erc721.tokenURI(first_token_id).call()
+string_uri = felt_to_str(felt_uri)
+----
+
+=== ERC721Received
+
+In order to be sure a contract can safely accept ERC721 tokens, said contract must implement the `ERC721_Receiver` interface (as expressed in the EIP721 specification).
+Methods such as `safeTransferFrom` and `safeMint` call the recipient contract's `onERC721Received` method.
+If the contract fails to return the correct magic value, the transaction fails.
+
+StarkNet contracts that support safe transfers, however, must also support xref:introspection.adoc#erc165[ERC165] and include `supportsInterface` as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
+`safeTransferFrom` requires a means of differentiating between account and non-account contracts.
+Currently, StarkNet does not support error handling from the contract level;
+therefore, the current ERC721 implementation requires that all contracts that support safe ERC721 transfers (both accounts and non-accounts) include the `supportsInterface` method.
+Further, `supportsInterface` should return `TRUE` if the recipient contract supports the `IERC721Receiver` magic value `0x150b7a02` (which invokes `onERC721Received`).
+If the recipient contract supports the `IAccount` magic value `0x50b70dcb`, `supportsInterface` should return `TRUE`.
+Otherwise, `safeTransferFrom` should fail.
+
+==== IERC721Receiver
+
+Interface for any contract that wants to support safeTransfers from ERC721 asset contracts.
+
+[,cairo]
+----
+@contract_interface
+namespace IERC721Receiver {
+    func onERC721Received(
+        operator: felt, from_: felt, tokenId: Uint256, data_len: felt data: felt*) -> (selector: felt) {
+    }
+}
+----
+
+=== Supporting Interfaces
+
+In order to ensure EVM/StarkNet compatibility, this ERC721 implementation does not calculate interface identifiers.
+Instead, the interface IDs are hardcoded from their EVM calculations.
+On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long.
+Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.
+
+Further, this implementation stores supported interfaces in a mapping (similar to OpenZeppelin's https://github.com/OpenZeppelin/openzeppelin-contracts/blob/release-v0.6.1/contracts/utils/introspection/ERC165Storage.sol[ERC165Storage]).
+
+=== Ready-to-Use Presets
+
+ERC721 presets have been created to allow for quick deployments as-is.
+To be as explicit as possible, each preset includes the additional features they offer in the contract name.
+For example:
+
+* `ERC721MintableBurnable` includes `mint` and `burn`.
+* `ERC721MintablePausable` includes `mint`, `pause`, and `unpause`.
+* `ERC721EnumerableMintableBurnable` includes `mint`, `burn`, and <<ierc721enumerable,IERC721Enumerable>> methods.
+
+Ready-to-use presets are a great option for testing and prototyping.
+See <<presets,Presets>>.
+
+== Extensibility
+
+Following the xref:extensibility.adoc[contracts extensibility pattern], this implementation is set up to include all ERC721 related storage and business logic under a namespace.
+Developers should be mindful of manually exposing the required methods from the namespace to comply with the standard interface.
+This is already done in the <<presets,preset contracts>>;
+however, additional functionality can be added.
+For instance, you could:
+
+* Implement a pausing mechanism.
+* Add roles such as _owner_ or _minter_.
+* Modify the `transferFrom` function to mimic the https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol#L335[`_beforeTokenTransfer` and `_afterTokenTransfer` hooks].
+
+Just be sure that the exposed `external` methods invoke their imported function logic a la `approve` invokes `ERC721.approve`.
+As an example, see below.
+
+[,python]
+----
+from openzeppelin.token.erc721.library import ERC721
+
+@external
+func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    ERC721.approve(to, tokenId)
+    return()
+}
+----
+
+== Presets
+
+The following contract presets are ready to deploy and can be used as-is for quick prototyping and testing.
+Each preset includes a contract owner, which is set in the `constructor`, to offer simple access control on sensitive methods such as `mint` and `burn`.
+
+=== ERC721MintableBurnable
+
+The `ERC721MintableBurnable` preset offers a quick and easy setup for creating NFTs.
+The contract owner can create tokens with `mint`, whereas token owners can destroy their tokens with `burn`.
+
+=== ERC721MintablePausable
+
+The `ERC721MintablePausable` preset creates a contract with pausable token transfers and minting capabilities.
+This preset proves useful for scenarios such as preventing trades until the end of an evaluation period and having an emergency switch for freezing all token transfers in the event of a large bug.
+In this preset, only the contract owner can `mint`, `pause`, and `unpause`.
+
+=== ERC721EnumerableMintableBurnable
+
+The `ERC721EnumerableMintableBurnable` preset adds enumerability of all the token ids in the contract as well as all token ids owned by each account.
+This allows contracts to publish its full list of NFTs and make them discoverable.
+
+In regard to implementation, contracts should expose the following view methods:
+
+* `ERC721Enumerable.total_supply`
+* `ERC721Enumerable.token_by_index`
+* `ERC721Enumerable.token_of_owner_by_index`
+
+In order for the tokens to be correctly indexed, the contract should also use the following methods (which supersede some of the base `ERC721` methods):
+
+* `ERC721Enumerable.transfer_from`
+* `ERC721Enumerable.safe_transfer_from`
+* `ERC721Enumerable._mint`
+* `ERC721Enumerable._burn`
+
+==== IERC721Enumerable
+
+[,cairo]
+----
+@contract_interface
+namespace IERC721Enumerable {
+    func totalSupply() -> (totalSupply: Uint256) {
+    }
+
+    func tokenByIndex(index: Uint256) -> (tokenId: Uint256) {
+    }
+
+    func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256) {
+    }
+}
+----
+
+=== ERC721Metadata
+
+The `ERC721Metadata` extension allows your smart contract to be interrogated for its name and for details about the assets which your NFTs represent.
+
+We follow OpenZeppelin's Solidity approach of integrating the Metadata methods `name`, `symbol`, and `tokenURI` into all ERC721 implementations.
+If preferred, a contract can be created that does not import the Metadata methods from the `ERC721` library.
+Note that the `IERC721Metadata` interface id should be removed from the constructor as well.
+
+==== IERC721Metadata
+
+[,cairo]
+----
+@contract_interface
+namespace IERC721Metadata {
+    func name() -> (name: felt) {
+    }
+
+    func symbol() -> (symbol: felt) {
+    }
+
+    func tokenURI(tokenId: Uint256) -> (tokenURI: felt) {
+    }
+}
+----
+
+== Utilities
+
+=== ERC721Holder
+
+Implementation of the `IERC721Receiver` interface.
+
+Accepts all token transfers.
+Make sure the contract is able to use its token with `IERC721.safeTransferFrom`, `IERC721.approve` or `IERC721.setApprovalForAll`.
+
+Also utilizes the ERC165 method `supportsInterface` to determine if the contract is an account.
+See <<erc721received,ERC721Received>>
+
+== API Specification
+
+=== IERC721 API
+
+[,cairo]
+----
+func balanceOf(owner: felt) -> (balance: Uint256) {
+}
+
+func ownerOf(tokenId: Uint256) -> (owner: felt) {
+}
+
+func safeTransferFrom(from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*) {
+}
+
+func transferFrom(from_: felt, to: felt, tokenId: Uint256) {
+}
+
+func approve(approved: felt, tokenId: Uint256) {
+}
+
+func setApprovalForAll(operator: felt, approved: felt) {
+}
+
+func getApproved(tokenId: Uint256) -> (approved: felt) {
+}
+
+func isApprovedForAll(owner: felt, operator: felt) -> (approved: felt) {
+}
+----
+
+==== `balanceOf`
+
+Returns the number of tokens in ``owner``'s account.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+----
+
+Returns:
+
+[,cairo]
+----
+balance: Uint256
+----
+
+==== `ownerOf`
+
+Returns the owner of the `tokenId` token.
+
+Parameters:
+
+[,cairo]
+----
+tokenId: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+owner: felt
+----
+
+==== `safeTransferFrom`
+
+Safely transfers `tokenId` token from `from_` to `to`, checking first that contract recipients are aware of the ERC721 protocol to prevent tokens from being forever locked.
+For information regarding how contracts communicate their awareness of the ERC721 protocol, see <<erc721received,ERC721Received>>.
+
+Emits a <<transfer_event,Transfer>> event.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+tokenId: Uint256
+data_len: felt
+data: felt*
+----
+
+Returns: None.
+
+==== `transferFrom`
+
+Transfers `tokenId` token from `from_` to `to`.
+*The caller is responsible to confirm that `to` is capable of receiving NFTs or else they may be permanently lost*.
+
+Emits a <<transfer_event,Transfer>> event.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+tokenId: Uint256
+----
+
+Returns: None.
+
+==== `approve`
+
+Gives permission to `to` to transfer `tokenId` token to another account.
+The approval is cleared when the token is transferred.
+
+Emits an <<approval_event,Approval>> event.
+
+Parameters:
+
+[,cairo]
+----
+to: felt
+tokenId: Uint256
+----
+
+Returns: None.
+
+==== `getApproved`
+
+Returns the account approved for `tokenId` token.
+
+Parameters:
+
+[,cairo]
+----
+tokenId: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+operator: felt
+----
+
+==== `setApprovalForAll`
+
+Approve or remove `operator` as an operator for the caller.
+Operators can call `transferFrom` or `safeTransferFrom` for any token owned by the caller.
+
+Emits an <<approvalforall_event,ApprovalForAll>> event.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+----
+
+Returns: None.
+
+==== `isApprovedForAll`
+
+Returns if the `operator` is allowed to manage all of the assets of `owner`.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+operator: felt
+----
+
+Returns:
+
+[,cairo]
+----
+approved: felt
+----
+
+=== Events
+
+==== `Approval (Event)`
+
+Emitted when `owner` enables `approved` to manage the `tokenId` token.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+approved: felt
+tokenId: Uint256
+----
+
+==== `ApprovalForAll (Event)`
+
+Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+operator: felt
+approved: felt
+----
+
+==== `Transfer (Event)`
+
+Emitted when `tokenId` token is transferred from `from_` to `to`.
+
+Parameters:
+
+[,cairo]
+----
+from_: felt
+to: felt
+tokenId: Uint256
+----
+
+'''
+
+=== IERC721Metadata API
+
+[,cairo]
+----
+func name() -> (name: felt) {
+}
+
+func symbol() -> (symbol: felt) {
+}
+
+func tokenURI(tokenId: Uint256) -> (tokenURI: felt) {
+}
+----
+
+==== `name`
+
+Returns the token collection name.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+name: felt
+----
+
+==== `symbol`
+
+Returns the token collection symbol.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+symbol: felt
+----
+
+==== `tokenURI`
+
+Returns the Uniform Resource Identifier (URI) for `tokenID` token.
+If the URI is not set for the `tokenId`, the return value will be `0`.
+
+Parameters:
+
+[,cairo]
+----
+tokenId: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+tokenURI: felt
+----
+
+'''
+
+=== IERC721Enumerable API
+
+[,cairo]
+----
+func totalSupply() -> (totalSupply: Uint256) {
+}
+
+func tokenByIndex(index: Uint256) -> (tokenId: Uint256) {
+}
+
+func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256) {
+}
+----
+
+==== `totalSupply`
+
+Returns the total amount of tokens stored by the contract.
+
+Parameters: None
+
+Returns:
+
+[,cairo]
+----
+totalSupply: Uint256
+----
+
+==== `tokenByIndex`
+
+Returns a token ID owned by `owner` at a given `index` of its token list.
+Use along with <<balanceof,balanceOf>> to enumerate all of ``owner``'s tokens.
+
+Parameters:
+
+[,cairo]
+----
+index: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+tokenId: Uint256
+----
+
+==== `tokenOfOwnerByIndex`
+
+Returns a token ID at a given `index` of all the tokens stored by the contract.
+Use along with <<totalsupply,totalSupply>> to enumerate all tokens.
+
+Parameters:
+
+[,cairo]
+----
+owner: felt
+index: Uint256
+----
+
+Returns:
+
+[,cairo]
+----
+tokenId: Uint256
+----
+
+'''
+
+=== IERC721Receiver API
+
+[,cairo]
+----
+func onERC721Received(
+    operator: felt, from_: felt, tokenId: Uint256, data_len: felt data: felt*
+) -> (selector: felt) {
+}
+----
+
+==== `onERC721Received`
+
+Whenever an IERC721 `tokenId` token is transferred to this non-account contract via `safeTransferFrom` by `operator` from `from_`, this function is called.
+
+Parameters:
+
+[,cairo]
+----
+operator: felt
+from_: felt
+tokenId: Uint256
+data_len: felt
+data: felt*
+----
+
+Returns:
+
+[,cairo]
+----
+selector: felt
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/extensibility.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/extensibility.adoc
@@ -1,0 +1,166 @@
+= Extensibility
+
+NOTE: Expect this pattern to evolve (as it has already done) or even disappear if https://community.starknet.io/t/contract-extensibility-pattern/210/11?u=martriay[proper extensibility features] are implemented into Cairo.
+
+== Table of Contents
+
+* <<the_extensibility_problem,The extensibility problem>>
+* <<the_pattern,The pattern ™️>>
+ ** <<libraries,Libraries>>
+ ** <<contracts,Contracts>>
+* <<presets,Presets>>
+* <<function_names_and_coding_style,Function names and coding style>>
+* <<emulating_hooks,Emulating hooks>>
+
+== The extensibility problem
+
+Smart contract development is a critical task.
+As with all software development, it is error prone;
+but unlike most scenarios, a bug can result in major losses for organizations as well as individuals.
+Therefore writing complex smart contracts is a delicate task.
+
+One of the best approaches to minimize introducing bugs is to reuse existing, battle-tested code, a.k.a.
+using libraries.
+But code reutilization in StarkNet's smart contracts is not easy:
+
+* Cairo has no explicit smart contract extension mechanisms such as inheritance or composability.
+* Using imports for modularity can result in clashes (more so given that arguments are not part of the selector), and lack of overrides or aliasing leaves no way to resolve them.
+* Any `@external` function defined in an imported module will be automatically re-exposed by the importer (i.e.
+the smart contract).
+
+To overcome these problems, this project builds on the following guidelines™.
+
+== The pattern
+
+The idea is to have two types of Cairo modules: libraries and contracts.
+Libraries define reusable logic and storage variables which can then be extended and exposed by contracts.
+Contracts can be deployed, libraries cannot.
+
+To minimize risk, boilerplate, and avoid function naming clashes, we follow these rules:
+
+=== Libraries
+
+Considering the following types of functions:
+
+* `private`: private to a library, not meant to be used outside the module or imported.
+* `public`: part of the public API of a library.
+* `internal`: subset of `public` that is either discouraged or potentially unsafe (e.g.
+`_transfer` on ERC20).
+* `external`: subset of `public` that is ready to be exported as-is by contracts (e.g.
+`transfer` on ERC20).
+* `storage`: storage variable functions.
+
+Then:
+
+* Must implement `public` and `external` functions under a namespace.
+* Must implement `private` functions outside the namespace to avoid exposing them.
+* Must prefix `internal` functions with an underscore (e.g.
+`ERC20._mint`).
+* Must not prefix `external` functions with an underscore (e.g.
+`ERC20.transfer`).
+* Must prefix `storage` functions with the name of the namespace to prevent clashing with other libraries (e.g.
+`ERC20balances`).
+* Must not implement any `@external`, `@view`, or `@constructor` functions.
+* Can implement initializers (never as `@constructor` or `@external`).
+* Must not call initializers on any function.
+
+=== Contracts
+
+* Can import from libraries.
+* Should implement `@external` functions if needed.
+* Should implement a `@constructor` function that calls initializers.
+* Must not call initializers in any function beside the constructor.
+
+Note that since initializers will never be marked as `@external` and they won't be called from anywhere but the constructor, there's no risk of re-initialization after deployment.
+It's up to the library developers not to make initializers interdependent to avoid weird dependency paths that may lead to double construction of libraries.
+
+== Presets
+
+Presets are pre-written contracts that extend from our library of contracts.
+They can be deployed as-is or used as templates for customization.
+
+Some presets are:
+
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/account/presets/Account.cairo[Account]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/tests/mocks/ERC165.cairo[ERC165]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo[ERC20Mintable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo[ERC20Pausable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo[ERC20Upgradeable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20.cairo[ERC20]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc721/presets/ERC721MintableBurnable.cairo[ERC721MintableBurnable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc721/presets/ERC721MintablePausable.cairo[ERC721MintablePausable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc721/enumerable/presets/ERC721EnumerableMintableBurnable.cairo[ERC721EnumerableMintableBurnable]
+
+In previous versions of Cairo importing any function from a module would automatically import all `@external` functions. We used to leverage this behavior to just import the constructor of the preset contract to load it.
+Since Cairo v0.10, however, contracts that utilize the preset contracts should import all of the exposed functions from it. For example:
+
+[,cairo]
+```
+%lang starknet
+
+from openzeppelin.token.erc20.presets.ERC20 import constructor
+```
+
+should now look like:
+
+[,cairo]
+```
+%lang starknet
+
+from openzeppelin.token.erc20.presets.ERC20 import (
+    constructor,
+    name,
+    symbol,
+    totalSupply,
+    decimals,
+    balanceOf,
+    allowance,
+    transfer,
+    transferFrom,
+    approve,
+    increaseAllowance,
+    decreaseAllowance
+)
+```
+
+
+== Function names and coding style
+
+* Following Cairo's programming style, we use `snake_case` for library APIs (e.g.
+`ERC20.transfer_from`, `ERC721.safe_transfer_from`).
+* But for standard EVM ecosystem compatibility, we implement external functions in contracts using `camelCase` (e.g.
+`transferFrom` in a ERC20 contract).
+* Guard functions such as the so-called "only owner" are prefixed with `assert_` (e.g.
+`Ownable.assert_only_owner`).
+
+== Emulating hooks
+
+Unlike the Solidity version of https://github.com/OpenZeppelin/openzeppelin-contracts[OpenZeppelin Contracts], this library does not implement https://docs.openzeppelin.com/contracts/4.x/extending-contracts#using-hooks[hooks].
+The main reason being that Cairo does not support overriding functions.
+
+This is what a hook looks like in Solidity:
+
+[,solidity]
+----
+abstract contract ERC20Pausable is ERC20, Pausable {
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual override {
+        super._beforeTokenTransfer(from, to, amount);
+
+        require(!paused(), "ERC20Pausable: token transfer while paused");
+    }
+}
+----
+
+Instead, the extensibility pattern allows us to simply extend the library implementation of a function (namely `transfer`) by adding lines before or after calling it.
+This way, we can get away with:
+
+[,cairo]
+----
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.transfer(recipient, amount);
+}
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/index.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/index.adoc
@@ -1,0 +1,115 @@
+= Contracts for Cairo
+
+*A library for secure smart contract development* written in Cairo for https://starkware.co/product/starknet/[StarkNet], a decentralized ZK Rollup.
+
+== Usage
+
+WARNING: This repo contains highly experimental code. Expect rapid iteration. *Use at your own risk.*
+
+=== First time?
+
+Before installing Cairo on your machine, you need to install `gmp`:
+
+[,bash]
+----
+sudo apt install -y libgmp3-dev # linux
+brew install gmp # mac
+----
+
+TIP: If you have any trouble installing gmp on your Apple M1 computer, https://github.com/OpenZeppelin/nile/issues/22[here's a list of potential solutions].
+
+=== Set up your project
+
+Create a directory for your project, then `cd` into it and create a Python virtual environment.
+
+[,bash]
+----
+mkdir my-project
+cd my-project
+python3 -m venv env
+source env/bin/activate
+----
+
+Install the https://github.com/OpenZeppelin/nile[Nile] development environment and then run `init` to kickstart a new project.
+Nile will create the project directory structure and install https://www.cairo-lang.org/docs/quickstart.html[the Cairo language], a https://github.com/Shard-Labs/starknet-devnet/[local network], and a https://docs.pytest.org/en/6.2.x/[testing framework].
+
+[,bash]
+----
+pip install cairo-nile
+nile init
+----
+
+=== Install the library
+
+[,bash]
+----
+pip install openzeppelin-cairo-contracts
+----
+
+WARNING: Installing directly through GitHub may contain incomplete or breaking implementations.
+While we aim not to introduce such changes, we still strongly recommend installing through https://github.com/OpenZeppelin/cairo-contracts/releases/[official releases].
+
+=== Use a basic preset
+
+Presets are ready-to-use contracts that you can deploy right away.
+They also serve as examples of how to use library modules.
+xref:extensibility.adoc#presets[Read more about presets].
+
+[,cairo]
+----
+// contracts/MyToken.cairo
+
+%lang starknet
+
+from openzeppelin.token.erc20.presets.ERC20 import (
+    constructor,
+    name,
+    symbol,
+    totalSupply,
+    decimals,
+    balanceOf,
+    allowance,
+    transfer,
+    transferFrom,
+    approve,
+    increaseAllowance,
+    decreaseAllowance
+)
+----
+
+Compile and deploy it right away:
+
+[,bash]
+----
+nile compile
+
+nile deploy MyToken <name> <symbol> <decimals> <initial_supply> <recipient> --alias my_token
+----
+
+NOTE: `<initial_supply>` is expected to be two integers i.e.
+`1` `0`.
+See xref:utilities.adoc#uint256[uint256] for more information.
+
+=== Write a custom contract using library modules
+
+xref:extensibility.adoc#libraries[Read more about libraries].
+
+[,cairo]
+----
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from openzeppelin.security.pausable.library import Pausable
+from openzeppelin.token.erc20.library import ERC20
+
+(...)
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.transfer(recipient, amount);
+}
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/introspection.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/introspection.adoc
@@ -1,0 +1,160 @@
+= Introspection
+
+CAUTION: Expect this module to evolve.
+
+== Table of Contents
+
+* <<erc165,ERC165>>
+ ** <<interface_calculations,Interface calculations>>
+ ** <<registering_interfaces,Registering interfaces>>
+ ** <<querying_interfaces,Querying interfaces>>
+ ** <<ierc165,IERC165>>
+ ** <<ierc165_api_specification,IERC165 API Specification>>
+  *** <<supportsinterface,`supportsInterface`>>
+ ** <<erc165_library_functions,ERC165 Library Functions>>
+  *** <<supportsinterface2,`supports_interface`>>
+  *** <<register_interface,`register_interface`>>
+
+== ERC165
+
+The ERC165 standard allows smart contracts to exercise https://en.wikipedia.org/wiki/Type_introspection[type introspection] on other contracts, that is, examining which functions can be called on them.
+This is usually referred to as a contract's interface.
+
+Cairo contracts, like Ethereum contracts, have no native concept of an interface, so applications must usually simply trust they are not making an incorrect call.
+For trusted setups this is a non-issue, but often unknown and untrusted third-party addresses need to be interacted with.
+There may even not be any direct calls to them!
+(e.g.
+ERC20 tokens may be sent to a contract that lacks a way to transfer them out of it, locking them forever).
+In these cases, a contract declaring its interface can be very helpful in preventing errors.
+
+It should be noted that the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/utils/constants/library.cairo[constants library] includes constant variables referencing all of the interface ids used in these contracts.
+This allows for more legible code i.e.
+using `IERC165_ID` instead of `0x01ffc9a7`.
+
+=== Interface calculations
+
+In order to ensure EVM/StarkNet compatibility, interface identifiers are not calculated on StarkNet.
+Instead, the interface IDs are hardcoded from their EVM calculations.
+On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long.
+Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.
+
+=== Registering interfaces
+
+For a contract to declare its support for a given interface, the contract should import the ERC165 library and register its support.
+It's recommended to register interface support upon contract deployment through a constructor either directly or indirectly (as an initializer) like this:
+
+[,cairo]
+----
+from openzeppelin.introspection.erc165.library import ERC165
+
+INTERFACE_ID = 0x12345678
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    ERC165.register_interface(INTERFACE_ID);
+    return ();
+}
+----
+
+=== Querying interfaces
+
+To query a target contract's support for an interface, the querying contract should call `supportsInterface` through IERC165 with the target contract's address and the queried interface id.
+Here's an example:
+
+[,cairo]
+----
+from openzeppelin.introspection.erc265.IERC165 import IERC165
+
+INTERFACE_ID = 0x12345678
+
+func check_support{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    target_contract: felt
+) -> (success: felt) {
+    let (is_supported) = IERC165.supportsInterface(target_contract, INTERFACE_ID);
+    return (is_supported);
+}
+----
+
+NOTE: `supportsInterface` is camelCased because it is an exposed contract method as part of ERC165's interface.
+This differs from library methods (such as `supports_interface` from the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/introspection/erc165/library.cairo[ERC165 library]) which are snake_cased and not exposed.
+See the xref:extensibility.adoc#function_names_and_coding_style[Function names and coding style] for more details.
+
+=== IERC165
+
+[,cairo]
+----
+@contract_interface
+namespace IERC165 {
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}
+----
+
+=== IERC165 API Specification
+
+[,cairo]
+----
+func supportsInterface(interfaceId: felt) -> (success: felt) {
+}
+----
+
+==== `supportsInterface`
+
+Returns true if this contract implements the interface defined by `interfaceId`.
+
+Parameters:
+
+[,cairo]
+----
+interfaceId: felt
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+=== ERC165 Library Functions
+
+[,cairo]
+----
+func supports_interface(interface_id: felt) -> (success: felt) {
+}
+
+func register_interface(interface_id: felt) {
+}
+----
+
+[#supportsinterface2]
+==== `supports_interface`
+
+Returns true if this contract implements the interface defined by `interface_id`.
+
+Parameters:
+
+[,cairo]
+----
+interface_id: felt
+----
+
+Returns:
+
+[,cairo]
+----
+success: felt
+----
+
+==== `register_interface`
+
+Calling contract declares support for a specific interface defined by `interface_id`.
+
+Parameters:
+
+[,cairo]
+----
+interface_id: felt
+----
+
+Returns: None.

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/proxies.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/proxies.adoc
@@ -1,0 +1,353 @@
+= Proxies
+
+NOTE: Expect rapid iteration as this pattern matures and more patterns potentially emerge.
+
+== Table of Contents
+
+* <<quickstart,Quickstart>>
+* <<soliditycairo_upgrades_comparison,Solidity/Cairo upgrades comparison>>
+ ** <<constructors,Constructors>>
+ ** <<storage,Storage>>
+* <<proxies2,Proxies>>
+ ** <<proxy_contract,Proxy contract>>
+ ** <<implementation_contract,Implementation contract>>
+* <<upgrades_library_api,Upgrades library API>>
+ ** <<methods,Methods>>
+ ** <<events,Events>>
+* <<using_proxies,Using proxies>>
+ ** <<contract_upgrades,Contract upgrades>>
+ ** <<declaring_contracts,Declaring contracts>>
+ ** <<testing_method_calls,Testing method calls>>
+* <<presets,Presets>>
+
+== Quickstart
+
+The general workflow is:
+
+. Declare an implementation https://starknet.io/docs/hello_starknet/intro.html#declare-the-contract-on-the-starknet-testnet[contract class].
+. Deploy proxy contract with the implementation contract's class hash, and the inputs describing the call to initialize the proxy from the implementation (if required). This will redirect the call as a library_call to the implementation (similar to Solidity delegatecall).
+
+In Python, this would look as follows:
+
+[,python]
+----
+# declare implementation contract
+IMPLEMENTATION = await starknet.declare(
+    "path/to/implementation.cairo",
+)
+
+# deploy proxy
+selector = get_selector_from_name('initializer')
+params = [
+    proxy_admin   # admin account
+]
+PROXY = await starknet.deploy(
+    "path/to/proxy.cairo",
+    constructor_calldata=[
+        IMPLEMENTATION.class_hash,  # set implementation contract class hash
+        selector,                   # initializer function selector
+        len(params),                # calldata length in felt
+        *params                     # actual calldata
+    ]
+)
+----
+
+== Solidity/Cairo upgrades comparison
+
+=== Constructors
+
+OpenZeppelin Contracts for Solidity requires the use of an alternative library for upgradeable contracts.
+Consider that in Solidity constructors are not part of the deployed contract's runtime bytecode;
+rather, a constructor's logic is executed only once when the contract instance is deployed and then discarded.
+This is why proxies can't imitate the construction of its implementation, therefore requiring a different initialization mechanism.
+
+The constructor problem in upgradeable contracts is resolved by the use of initializer methods.
+Initializer methods are essentially regular methods that execute the logic that would have been in the constructor.
+Care needs to be exercised with initializers to ensure they can only be called once.
+Thus, OpenZeppelin offers an https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable[upgradeable contracts library] where much of this process is abstracted away.
+See OpenZeppelin's https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable[Writing Upgradeable Contracts] for more info.
+
+The Cairo programming language does not support inheritance.
+Instead, Cairo contracts follow the xref:extensibility.adoc[Extensibility Pattern] which already uses initializer methods to mimic constructors.
+Upgradeable contracts do not, therefore, require a separate library with refactored constructor logic.
+
+=== Storage
+
+OpenZeppelin's alternative Upgrades library also implements https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies#unstructured-storage-proxies[unstructured storage] for its upgradeable contracts.
+The basic idea behind unstructured storage is to pseudo-randomize the storage structure of the upgradeable contract so it's based on variable names instead of declaration order, which makes the chances of storage collision during an upgrade extremely unlikely.
+
+The StarkNet compiler, meanwhile, already creates pseudo-random storage addresses by hashing the storage variable names (and keys in mappings) by default.
+In other words, StarkNet already uses unstructured storage and does not need a second library to modify how storage is set.
+See StarkNet's https://starknet.io/documentation/contracts/#contracts_storage[Contracts Storage documentation] for more information.
+
+[#proxies2]
+== Proxies
+
+A proxy contract is a contract that delegates function calls to another contract.
+This type of pattern decouples state and logic.
+Proxy contracts store the state and redirect function calls to an implementation contract that handles the logic.
+This allows for different patterns such as upgrades, where implementation contracts can change but the proxy contract (and thus the state) does not;
+as well as deploying multiple proxy instances pointing to the same implementation.
+This can be useful to deploy many contracts with identical logic but unique initialization data.
+
+In the case of contract upgrades, it is achieved by simply changing the proxy's reference to the class hash of the declared implementation.
+This allows developers to add features, update logic, and fix bugs without touching the state or the contract address to interact with the application.
+
+=== Proxy contract
+
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/upgrades/presets/Proxy.cairo[Proxy contract] includes two core methods:
+
+. The `\\__default__` method is a fallback method that redirects a function call and associated calldata to the implementation contract.
+. The `\\__l1_default__` method is also a fallback method;
+however, it redirects the function call and associated calldata to a layer one contract.
+In order to invoke `\\__l1_default__`, the original function call must include the library function `send_message_to_l1`.
+See Cairo's https://www.cairo-lang.org/docs/hello_starknet/l1l2.html[Interacting with L1 contracts] for more information.
+
+Since this proxy is designed to work both as an https://eips.ethereum.org/EIPS/eip-1822[UUPS-flavored upgrade proxy] as well as a non-upgradeable proxy, it does not know how to handle its own state.
+Therefore it requires the implementation contract class to be declared beforehand, so its class hash can be passed to the Proxy on construction time.
+
+When interacting with the contract, function calls should be sent by the user to the proxy.
+The proxy's fallback function redirects the function call to the implementation contract to execute.
+
+=== Implementation contract
+
+The implementation contract, also known as the logic contract, receives the redirected function calls from the proxy contract.
+The implementation contract should follow the xref:extensibility.adoc#the_pattern[Extensibility pattern] and import directly from the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/upgrades/library.cairo[Proxy library].
+
+The implementation contract should:
+
+* Import `Proxy` namespace.
+* Provide an external initializer function (calling `Proxy.initializer`) to intialize the proxy immediately after deployment.
+
+If the implementation is upgradeable, it should:
+
+* Include a method to upgrade the implementation (i.e.
+`upgrade`).
+* Use access control to protect the contract's upgradeability.
+
+The implementation contract should NOT:
+
+* Be deployed like a regular contract.
+Instead, the implementation contract should be declared (which creates a `DeclaredClass` containing its hash and abi).
+* Set its initial state with a traditional constructor (decorated with `@constructor`).
+Instead, use an initializer method that invokes the Proxy `constructor`.
+
+NOTE: The Proxy `constructor` includes a check that ensures the initializer can only be called once;
+however, `_set_implementation` does not include this check.
+It's up to the developers to protect their implementation contract's upgradeability with access controls such as <<assert_only_admin,`assert_only_admin`>>.
+
+For a full implementation contract example, please see:
+
+* https://github.com/OpenZeppelin/cairo-contracts/blob/main/tests/mocks/ProxiableImplementation.cairo[Proxiable implementation]
+
+== Upgrades library API
+
+=== Methods
+
+[,cairo]
+----
+func initializer(proxy_admin: felt) {
+}
+
+func assert_only_admin() {
+}
+
+func get_implementation_hash() -> (implementation: felt) {
+}
+
+func get_admin() -> (admin: felt) {
+}
+
+func _set_admin(new_admin: felt) {
+}
+
+func _set_implementation_hash(new_implementation: felt) {
+}
+----
+
+==== `initializer`
+
+Initializes the proxy contract with an initial implementation.
+
+Parameters:
+
+[,cairo]
+----
+proxy_admin: felt
+----
+
+Returns: None.
+
+==== `assert_only_admin`
+
+Reverts if called by any account other than the admin.
+
+Parameters: None.
+
+Returns: None.
+
+==== `get_implementation`
+
+Returns the current implementation hash.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+implementation: felt
+----
+
+==== `get_admin`
+
+Returns the current admin.
+
+Parameters: None.
+
+Returns:
+
+[,cairo]
+----
+admin: felt
+----
+
+==== `_set_admin`
+
+Sets `new_admin` as the admin of the proxy contract.
+
+Parameters:
+
+[,cairo]
+----
+new_admin: felt
+----
+
+Returns: None.
+
+==== `_set_implementation_hash`
+
+Sets `new_implementation` as the implementation's contract class.
+This method is included in the proxy contract's constructor and can be used to upgrade contracts.
+
+Parameters:
+
+[,cairo]
+----
+new_implementation: felt
+----
+
+Returns: None.
+
+=== Events
+
+[,cairo]
+----
+func Upgraded(implementation: felt) {
+}
+
+func AdminChanged(previousAdmin: felt, newAdmin: felt) {
+}
+----
+
+==== `Upgraded`
+
+Emitted when a proxy contract sets a new implementation class hash.
+
+Parameters:
+
+[,cairo]
+----
+implementation: felt
+----
+
+==== `AdminChanged`
+
+Emitted when the `admin` changes from `previousAdmin` to `newAdmin`.
+
+Parameters:
+
+[,cairo]
+----
+previousAdmin: felt
+newAdmin: felt
+----
+
+== Using proxies
+
+=== Contract upgrades
+
+To upgrade a contract, the implementation contract should include an `upgrade` method that, when called, changes the reference to a new deployed contract like this:
+
+[,python]
+----
+# declare first implementation
+IMPLEMENTATION = await starknet.declare(
+    "path/to/implementation.cairo",
+)
+
+# deploy proxy
+PROXY = await starknet.deploy(
+    "path/to/proxy.cairo",
+    constructor_calldata=[
+        IMPLEMENTATION.class_hash,  # set implementation hash
+        0,                          # selector set to 0 ignores initialization
+        0,                          # calldata length in felt
+        *[]                         # empty calldata
+    ]
+)
+
+# declare implementation v2
+IMPLEMENTATION_V2 = await starknet.declare(
+    "path/to/implementation_v2.cairo",
+)
+
+# call upgrade with the new implementation contract class hash
+await signer.send_transaction(
+    account, PROXY.contract_address, 'upgrade', [
+        IMPLEMENTATION_V2.class_hash
+    ]
+)
+----
+
+For a full deployment and upgrade implementation, please see:
+
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/tests/mocks/UpgradesMockV1.cairo[Upgrades V1]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/tests/mocks/UpgradesMockV2.cairo[Upgrades V2]
+
+=== Declaring contracts
+
+StarkNet contracts come in two forms: contract classes and contract instances.
+Contract classes represent the uninstantiated, stateless code;
+whereas, contract instances are instantiated and include the state.
+Since the Proxy contract references the implementation contract by its class hash, declaring an implementation contract proves sufficient (as opposed to a full deployment).
+For more information on declaring classes, see https://starknet.io/docs/hello_starknet/intro.html#declare-contract[StarkNet's documentation].
+
+=== Testing method calls
+
+As with most StarkNet contracts, interacting with a proxy contract requires an xref:accounts.adoc#quickstart[account abstraction].
+Due to limitations in the StarkNet testing framework, however, `@view` methods also require an account abstraction. This is only a requirement when testing.
+The differences in getter methods written in Python, for example, are as follows:
+
+[,python]
+----
+# standard ERC20 call
+result = await erc20.totalSupply().call()
+
+# upgradeable ERC20 call
+result = await signer.send_transaction(
+    account, PROXY.contract_address, 'totalSupply', []
+)
+----
+
+== Presets
+
+Presets are pre-written contracts that extend from our library of contracts.
+They can be deployed as-is or used as templates for customization.
+
+Some presets include:
+
+* https://github.com/OpenZeppelin/cairo-contracts/blob/ad399728e6fcd5956a4ed347fb5e8ee731d37ec4/src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo[ERC20Upgradeable]
+* More to come!
+Have an idea?
+https://github.com/OpenZeppelin/cairo-contracts/issues/new/choose[Open an issue]!

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/security.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/security.adoc
@@ -1,0 +1,121 @@
+= Security
+
+The following documentation provides context, reasoning, and examples of methods and constants found in `openzeppelin/security/`.
+
+CAUTION: Expect this module to evolve.
+
+== Table of Contents
+
+* <<initializable,Initializable>>
+* <<pausable,Pausable>>
+* <<reentrancy_guard,Reentrancy Guard>>
+* <<safemath,SafeMath>>
+ ** <<safeuint256,SafeUint256>>
+
+== Initializable
+
+The Initializable library provides a simple mechanism that mimics the functionality of a constructor.
+More specifically, it enables logic to be performed once and only once which is useful to setup a contract's initial state when a constructor cannot be used.
+
+The recommended pattern with Initializable is to include a check that the Initializable state is `False` and invoke `initialize` in the target function like this:
+
+[,cairo]
+----
+from openzeppelin.security.initializable.library import Initializable
+
+@external
+func foo{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() {
+    let (initialized) = Initializable.initialized();
+    assert initialized = FALSE;
+
+    Initializable.initialize();
+    return ();
+}
+----
+
+CAUTION: This Initializable pattern should only be used on one function.
+
+== Pausable
+
+The Pausable library allows contracts to implement an emergency stop mechanism.
+This can be useful for scenarios such as preventing trades until the end of an evaluation period or having an emergency switch to freeze all transactions in the event of a large bug.
+
+To use the Pausable library, the contract should include `pause` and `unpause` functions (which should be protected).
+For methods that should be available only when not paused, insert `assert_not_paused`.
+For methods that should be available only when paused, insert `assert_paused`.
+For example:
+
+[,cairo]
+----
+from openzeppelin.security.pausable.library import Pausable
+
+@external
+func whenNotPaused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable.assert_not_paused();
+
+    // function body
+
+    return ();
+}
+
+@external
+func whenPaused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable.assert_paused();
+
+    // function body
+
+    return ();
+}
+----
+
+NOTE: `pause` and `unpause` already include these assertions.
+In other words, `pause` cannot be invoked when already paused and vice versa.
+
+For a list of full implementations utilizing the Pausable library, see:
+
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo[ERC20Pausable]
+* https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/token/erc721/presets/ERC721MintablePausable.cairo[ERC721MintablePausable]
+
+== Reentrancy Guard
+
+A https://gus-tavo-guim.medium.com/reentrancy-attack-on-smart-contracts-how-to-identify-the-exploitable-and-an-example-of-an-attack-4470a2d8dfe4[reentrancy attack] occurs when the caller is able to obtain more resources than allowed by recursively calling a target's function.
+
+Since Cairo does not support modifiers like Solidity, the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/security/reentrancyguard/library.cairo[`reentrancy guard`] library exposes two methods `start` and `end` to protect functions against reentrancy attacks.
+The protected function must call `ReentrancyGuard.start` before the first function statement, and `ReentrancyGuard.end` before the return statement, as shown below:
+
+[,cairo]
+----
+from openzeppelin.security.reentrancyguard.library import ReentrancyGuard
+
+func test_function{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() {
+   ReentrancyGuard.start();
+
+   // function body
+
+   ReentrancyGuard.end();
+   return ();
+}
+----
+
+== SafeMath
+
+=== SafeUint256
+
+The SafeUint256 namespace in the https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/security/safemath/library.cairo[SafeMath library] offers arithmetic for unsigned 256-bit integers (uint256) by leveraging Cairo's Uint256 library and integrating overflow checks.
+Some of Cairo's Uint256 functions do not revert upon overflows.
+For instance, `uint256_add` will return a bit carry when the sum exceeds 256 bits.
+This library includes an additional assertion ensuring values do not overflow.
+
+Using SafeUint256 methods is rather straightforward.
+Simply import SafeUint256 and insert the arithmetic method like this:
+
+[,cairo]
+----
+from openzeppelin.security.safemath.library import SafeUint256
+
+func add_two_uints{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    a: Uint256, b: Uint256) -> (c: Uint256) {
+    let (c: Uint256) = SafeUint256.add(a, b);
+    return (c);
+}
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/udc.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/udc.adoc
@@ -1,0 +1,226 @@
+= Universal Deployer Contract
+
+The Universal Deployer Contract (UDC) is a singleton smart contract that wraps the https://www.cairo-lang.org/docs/hello_starknet/deploying_from_contracts.html#the-deploy-system-call[`deploy syscall`] to expose it to any contract that doesn't implement it, such as account contracts. You can think of it as a **standardized generic factory for StarkNet contracts**.
+
+And since StarkNet has no deployment transaction type, it offers a canonical way to deploy smart contracts by following the https://community.starknet.io/t/snip-deployer-contract-interface/2772[standard deployer interface] and emitting a `ContractDeployed` event.
+
+TIP: For information on design decisions, see the https://community.starknet.io/t/universal-deployer-contract-proposal/1864[Universal Deployer Contract Proposal].
+
+NOTE: The UDC address is `0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf` in mainnet, testnets, and starknet-devnet. This address may change in the future.
+
+== Table of Contents
+* <<quickstart, Quickstart>>
+* <<deploying_the_udc,Deploying the UDC>>
+* <<usage,Usage>>
+ ** <<deployer_dependent,Deployer dependent>>
+ ** <<deployer_independent,Deployer independent>>
+* <<calculating_counterfactual_addresses,Calculating counterfactual addresses>>
+* <<api_specification,API specification>>
+
+== Quickstart
+
+To deploy a contract first you need to make sure it's been declared and then send a `deployContract` transaction to the Universal Deployer Contract.
+Here's an example implementation in Python:
+
+[,python]
+----
+from nile.common import UNIVERSAL_DEPLOYER_ADDRESS
+
+signer = MockSigner(PRIVATE_KEY)
+
+async def deploy_contract():
+    # Declare the contract and get the class hash before deployment
+    class_hash, _ = await signer.declare_class(account, "Ownable")
+
+    # Set up deployment parameters
+    salt = 123456  # random number
+    unique = FALSE
+    calldata = [account.contract_address]
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+
+    # Send a "deployContract" transaction to the deployer contract
+    await account.send_transaction(
+        account,
+        UNIVERSAL_DEPLOYER_ADDRESS,
+        "deployContract",
+        params
+    )
+----
+
+=== Deploying the UDC
+
+NOTE: The Universal Deployer Contract has already been deployed on most networks and development environments.
+The deployment of the UDC requires `deploy_from_zero=TRUE` to be passed to the `deploy` syscall. This results in a deterministic and predictable address across all instances of StarkNet, facilitating SDK integration and reproducibility of deployments.
+
+== Usage
+
+The Universal Deployer Contract offers two types of addresses to deploy: deployer dependent and deployer independent.
+As the names suggest, the deployer-dependent type includes the deployer's address in the address calculation;
+whereas, the deployer-independent type does not.
+The `unique` boolean parameter ultimately determines the type of deployment.
+
+CAUTION: When deploying a contract that uses `get_caller_address` in the constructor calldata, remember that the UDC (and not the account) deploys that contract.
+Therefore, querying `get_caller_address` in a contract's constructor will return the UDC's address and *not* the account's address.
+
+=== Deployer dependent
+
+Making deployments dependent of the deployer address, users can "reserve" a whole address space from squatting by someone else.
+Only that deployer can deploy to those addresses.
+
+Achieving this type of deployment necessitates that the deployer sets `unique` to `TRUE` in the `deployContract` call.
+Under the hood, the function call leverages the deployer's address and creates a hashchain by hashing the deployer's address with the given salt.
+
+To deploy a unique contract address:
+
+[,python]
+----
+from nile.common import UNIVERSAL_DEPLOYER_ADDRESS
+
+signer = MockSigner(PRIVATE_KEY)
+
+async def deploy_contract():
+    # Declare the contract and get the class hash before deployment
+    class_hash, _ = await signer.declare_class(account, "Ownable")
+
+    # Set up deployment parameters
+    salt = 123456  # random number
+    unique = TRUE
+    calldata = [account.contract_address]
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+
+    # Send a "deployContract" transaction to the deployer contract
+    await account.send_transaction(
+        account,
+        UNIVERSAL_DEPLOYER_ADDRESS,
+        "deployContract",
+        params
+    )
+----
+
+
+=== Deployer independent
+
+Deployer-independent contract deployments create contract addresses independent of the deployer and the UDC instance.
+Instead only the class hash, salt, and constructor arguments determine the address.
+This type of deployment enables redeployments of accounts and known systems across multiple networks.
+To deploy a reproducible deployment, set `unique` to `FALSE`.
+
+[,python]
+----
+from nile.common import UNIVERSAL_DEPLOYER_ADDRESS
+
+signer = MockSigner(PRIVATE_KEY)
+
+async def deploy_contract():
+    # Declare the contract and get the class hash before deployment
+    class_hash, _ = await signer.declare_class(account, "Ownable")
+
+    # Set up deployment parameters
+    salt = 123456  # random number
+    unique = FALSE
+    calldata = [account.contract_address]
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+
+    # Send a "deployContract" transaction to the deployer contract
+    await account.send_transaction(
+        account,
+        UNIVERSAL_DEPLOYER_ADDRESS,
+        "deployContract",
+        params
+    )
+----
+
+== Calculating counterfactual addresses
+
+Counterfactual addresses are contract addresses that haven't been deployed yet.
+A strong use-case for calculating a contract's counterfactual address lies in deploying account contracts.
+See xref:accounts.adoc#counterfactual_deployments[Counterfactual Deployments].
+
+To predict the counterfactual address, use the StarkWare library's `calculate_contract_address_from_hash` and pass the same arguments that will be used for the actual deployment.
+For example:
+
+[,python]
+----
+from starkware.starknet.core.os.contract_address.contract_address import (
+    calculate_contract_address_from_hash,
+)
+
+expected_address = calculate_contract_address_from_hash(
+    salt=salt,
+    class_hash=class_hash,
+    constructor_calldata=calldata,
+    deployer_address=deployer_address
+)
+----
+
+== API specification
+
+=== Methods
+
+[,cairo]
+----
+func deployContract(
+    classHash: felt,
+    salt: felt,
+    unique: felt,
+    calldata_len: felt,
+    calldata: felt*
+) -> (address: felt) {
+}
+
+----
+
+==== deployContract
+
+Deploy a contract through the Universal Deploy Contract.
+
+Parameters:
+
+[,cairo]
+----
+classHash: felt
+salt: felt
+unique: felt
+calldata_len: felt
+calldata: felt*
+----
+
+Returns:
+
+[,cairo]
+----
+address: felt
+----
+
+=== Events
+
+[,cairo]
+----
+func ContractDeployed(
+    address: felt,
+    deployer: felt,
+    unique: felt,
+    classHash: felt,
+    calldata_len: felt,
+    calldata: felt*,
+    salt: felt
+) {
+}
+----
+
+==== `ContractDeployed`
+
+Emitted when `deployer` deploys a contract through the Universal Deployer Contract.
+
+Parameters:
+
+[,cairo]
+----
+address: felt,
+deployer: felt,
+unique: felt,
+classHash: felt,
+calldata_len: felt,
+calldata: felt*,
+salt: felt
+----

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/utilities.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/utilities.adoc
@@ -1,0 +1,320 @@
+= Utilities
+
+The following documentation provides context, reasoning, and examples for methods and constants found in `tests/utils.py`.
+
+CAUTION: Expect this module to evolve (as it has already done).
+
+== Table of Contents
+
+* <<constants,Constants>>
+* <<strings,Strings>>
+ ** <<str_to_felt,`str_to_felt`>>
+ ** <<felt_to_str,`felt_to_str`>>
+* <<uint256,Uint256>>
+ ** <<uint,`uint`>>
+ ** <<to_uint,`to_uint`>>
+ ** <<from_uint,`from_uint`>>
+ ** <<add_uint,`add_uint`>>
+ ** <<sub_uint,`sub_uint`>>
+* <<assertions,Assertions>>
+ ** <<assert_revert,`assert_revert`>>
+ ** <<assert_revert_entry_point,`assert_revert_entry_point`>>
+ ** <<assert_event_emitted,`assert_events_emitted`>>
+* <<memoization,Memoization>>
+ ** <<get_contract_class,`get_contract_class`>>
+ ** <<cached_contract,`cached_contract`>>
+* <<state,State>>
+* <<account,Account>>
+* <<mocksigner,MockSigner>>
+
+== Constants
+
+To ease the readability of Cairo contracts, this project includes reusable https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.6.1/src/openzeppelin/utils/constants/library.cairo[constant variables] like `UINT8_MAX`, or EIP165 interface IDs such as `IERC165_ID` or `IERC721_ID`.
+For more information on how interface ids are calculated, see the xref:introspection.adoc#interface_calculations[ERC165 documentation].
+
+== Strings
+
+Cairo currently only provides support for short string literals (less than 32 characters).
+Note that short strings aren't really strings, rather, they're representations of Cairo field elements.
+The following methods provide a simple conversion to/from field elements.
+
+=== `str_to_felt`
+
+Takes an ASCII string and converts it to a field element via big endian representation.
+
+=== `felt_to_str`
+
+Takes an integer and converts it to an ASCII string by trimming the null bytes and decoding the remaining bits.
+
+== Uint256
+
+Cairo's native data type is a field element (felt).
+Felts equate to 252 bits which poses a problem regarding 256-bit integer integration.
+To resolve the bit discrepancy, Cairo represents 256-bit integers as a struct of two 128-bit integers.
+Further, the low bits precede the high bits e.g.
+
+[,python]
+----
+1 = (1, 0)
+1 << 128 = (0, 1)
+(1 << 128) - 1 = (340282366920938463463374607431768211455, 0)
+----
+
+=== `uint`
+
+Converts a simple integer into a uint256-ish tuple.
+
+____
+Note `to_uint` should be used in favor of `uint`, as `uint` only returns the low bits of the tuple.
+____
+
+=== `to_uint`
+
+Converts an integer into a uint256-ish tuple.
+
+[,python]
+----
+x = to_uint(340282366920938463463374607431768211456)
+print(x)
+# prints (0, 1)
+----
+
+=== `from_uint`
+
+Converts a uint256-ish tuple into an integer.
+
+[,python]
+----
+x = (0, 1)
+y = from_uint(x)
+print(y)
+# prints 340282366920938463463374607431768211456
+----
+
+=== `add_uint`
+
+Performs addition between two uint256-ish tuples and returns the sum as a uint256-ish tuple.
+
+[,python]
+----
+x = (0, 1)
+y = (1, 0)
+z = add_uint(x, y)
+print(z)
+# prints (1, 1)
+----
+
+=== `sub_uint`
+
+Performs subtraction between two uint256-ish tuples and returns the difference as a uint256-ish tuple.
+
+[,python]
+----
+x = (0, 1)
+y = (1, 0)
+z = sub_uint(x, y)
+print(z)
+# prints (340282366920938463463374607431768211455, 0)
+----
+
+=== `mul_uint`
+
+Performs multiplication between two uint256-ish tuples and returns the product as a uint256-ish tuple.
+
+[,python]
+----
+x = (0, 10)
+y = (2, 0)
+z = mul_uint(x, y)
+print(z)
+# prints (0, 20)
+----
+
+=== `div_rem_uint`
+
+Performs division between two uint256-ish tuples and returns both the quotient and remainder as uint256-ish tuples respectively.
+
+[,python]
+----
+x = (1, 100)
+y = (0, 25)
+z = div_rem_uint(x, y)
+print(z)
+# prints ((4, 0), (1, 0))
+----
+
+== Assertions
+
+In order to abstract away some of the verbosity regarding test assertions on StarkNet transactions, this project includes the following helper methods:
+
+=== `assert_revert`
+
+An asynchronous wrapper method that executes a try-except pattern for transactions that should fail.
+Note that this wrapper does not check for a StarkNet error code.
+This allows for more flexibility in checking that a transaction simply failed.
+If you wanted to check for an exact error code, you could use StarkNet's https://github.com/starkware-libs/cairo-lang/blob/ed6cf8d6cec50a6ad95fa36d1eb4a7f48538019e/src/starkware/starknet/definitions/error_codes.py[error_codes module] and implement additional logic to the `assert_revert` method.
+
+To successfully use this wrapper, the transaction method should be wrapped with `assert_revert`;
+however, `await` should precede the wrapper itself like this:
+
+[,python]
+----
+await assert_revert(signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ])
+)
+----
+
+This wrapper also includes the option to check that an error message was included in the reversion.
+To check that the reversion sends the correct error message, add the `reverted_with` keyword argument outside of the actual transaction (but still inside the wrapper) like this:
+
+[,python]
+----
+await assert_revert(signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ]),
+    reverted_with="insert error message here"
+)
+----
+
+=== `assert_revert_entry_point`
+
+An extension of `assert_revert` that asserts an entry point error occurs with the given `invalid_selector` parameter.
+This assertion is especially useful in checking proxy/implementation contracts.
+To use `assert_revert_entry_point`:
+
+[,python]
+----
+await assert_revert_entry_point(
+    signer.send_transaction(
+        account, contract.contract_address, 'nonexistent_selector', []
+    ),
+    invalid_selector='nonexistent_selector'
+)
+----
+
+=== `assert_event_emitted`
+
+A helper method that checks a transaction receipt for the contract emitting the event (`from_address`), the emitted event itself (`name`), and the arguments emitted (`data`).
+To use `assert_event_emitted`:
+
+[,python]
+----
+# capture the tx receipt
+tx_exec_info = await signer.send_transaction(
+    account, contract.contract_address, 'foo', [
+        recipient,
+        *token
+    ])
+
+# insert arguments to assert
+assert_event_emitted(
+    tx_exec_info,
+    from_address=contract.contract_address,
+    name='Foo_emitted',
+    data=[
+        account.contract_address,
+        recipient,
+        *token
+    ]
+)
+----
+
+== Memoization
+
+Memoizing functions allow for quicker and computationally cheaper calculations which is immensely beneficial while testing smart contracts.
+
+=== `get_contract_class`
+
+A helper method that returns the contract class from the contract's name.
+To capture the contract class, simply add the contract's name as an argument like this:
+
+[,python]
+----
+contract_class = get_contract_class('ContractName')
+----
+
+If multiple contracts exist with the same name, then the contract's path must be passed along with the `is_path` flag instead of the name.
+To pass the contract's path:
+
+[,python]
+----
+contract_class = get_contract_class('path/to/Contract.cairo', is_path=True)
+----
+
+=== `cached_contract`
+
+A helper method that returns the cached state of a given contract.
+It's recommended to first deploy all the relevant contracts before caching the state.
+The requisite contracts in the testing module should each be instantiated with `cached_contract` in a fixture after the state has been copied.
+The memoization pattern with `cached_contract` should look something like this:
+
+[,python]
+----
+# get contract classes
+@pytest.fixture(scope='module')
+def contract_classes():
+  foo_cls = get_contract_class('Foo')
+  return foo_cls
+
+# deploy contracts
+@pytest.fixture(scope='module')
+async def foo_init(contract_classes):
+    foo_cls = contract_classes
+    starknet = await Starknet.empty()
+    foo = await starknet.deploy(
+        contract_class=foo_cls,
+        constructor_calldata=[]
+    )
+    return starknet.state, foo  # return state and all deployed contracts
+
+# memoization
+@pytest.fixture
+def foo_factory(contract_classes, foo_init):
+    foo_cls = contract_classes                          # contract classes
+    state, foo = foo_init                               # state and deployed contracts
+    _state = state.copy()                               # copy the state
+    cached_foo = cached_contract(_state, foo_cls, foo)  # cache contracts
+    return cached_foo                                   # return cached contracts
+----
+
+== State
+
+The `State` class provides a wrapper for initializing the StarkNet state which acts as a helper for the `Account` class. This wrapper allows `Account` deployments to share the same initialized state without explicitly passing the instantiated StarkNet state to `Account`. Initializing the state should look like this:
+
+[,python]
+----
+from utils import State
+
+starknet = await State.init()
+----
+
+== Account
+
+The `Account` class abstracts away most of the boilerplate for deploying accounts. Instantiating accounts with this class requires the StarkNet state to be instantiated first with the `State.init()` method like this:
+
+[,python]
+----
+from utils import State, Account
+
+starknet = await State.init()
+account1 = await Account.deploy(public_key)
+account2 = await Account.deploy(public_key)
+----
+
+The Account class also provides access to the account contract class which is useful for following the <<memoization,Memoization>> pattern. To fetch the account contract class:
+
+[,python]
+----
+fetch_class = Account.get_class
+----
+
+== MockSigner
+
+`MockSigner` is used to perform transactions with an instance of https://github.com/OpenZeppelin/nile/blob/main/src/nile/signer.py[Nile's Signer] on a given Account, crafting the transaction and managing nonces.
+The `Signer` instance manages signatures and is leveraged by `MockSigner` to operate with the Account contract's `\\__execute__` method.
+See xref:accounts.adoc#mocksigner_utility[MockSigner utility] for more information.

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/wizard.adoc
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/modules/ROOT/pages/wizard.adoc
@@ -1,0 +1,14 @@
+= Cairo Contracts Wizard
+:page-notoc:
+
+Not sure where to start? Use the interactive generator below to bootstrap your
+contract and learn about the components offered in OpenZeppelin Cairo Contracts.
+
+
+NOTE: We strongly recommend checking the xref:extensibility.adoc[Extensibility Pattern] to understand how to extend from our library.
+
+++++
+<script async src="https://wizard.openzeppelin.com/build/embed.js"></script>
+
+<oz-wizard style="display: block; min-height: 40rem;" data-lang="cairo"></oz-wizard>
+++++

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/package-lock.json
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/package-lock.json
@@ -1,0 +1,2300 @@
+{
+  "name": "docs",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@openzeppelin/docs-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/docs-utils/-/docs-utils-0.1.2.tgz",
+      "integrity": "sha512-oBchkfFlpqHCee/HaNXPvFy8py9Yi/LTnaE2Vsf+eO4j/FSaupzBsFIgxESjdTScSvJcIOWZFsbZDDRKscg2DQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "chokidar": "^3.3.0",
+        "env-paths": "^2.2.0",
+        "find-up": "^4.1.0",
+        "is-port-reachable": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "live-server": "^1.2.1",
+        "lodash.startcase": "^4.4.0",
+        "minimist": "^1.2.0"
+      }
+    },
+    "accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "apache-crypt": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.5.tgz",
+      "integrity": "sha512-ICnYQH+DFVmw+S4Q0QY2XRXD8Ne8ewh8HgbuFH4K7022zCxgHM0Hz1xkRnUlEfAXNbwp1Cnhbedu60USIfDxvg==",
+      "dev": true,
+      "requires": {
+        "unix-crypt-td-js": "^1.1.4"
+      }
+    },
+    "apache-md5": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.7.tgz",
+      "integrity": "sha512-JtHjzZmJxtzfTSjsCyHgPR155HBe5WGyUyHTaEkfy46qhwCFKx1Epm6nAxgUG3WfUZP1dWhGqj9Z2NOBeZ+uBw==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "dev": true
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+      "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        }
+      }
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
+      "dev": true
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
+    "connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.2",
+        "parseurl": "~1.3.3",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "dev": true
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      }
+    },
+    "depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        }
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "dev": true
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "http-auth": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-3.1.3.tgz",
+      "integrity": "sha512-Jbx0+ejo2IOx+cRUYAGS1z6RGc6JfYUNkysZM4u4Sfk1uLlGv814F7/PIjQQAuThLdAWxb74JMGd5J8zex1VQg==",
+      "dev": true,
+      "requires": {
+        "apache-crypt": "^1.1.2",
+        "apache-md5": "^1.0.6",
+        "bcryptjs": "^2.3.0",
+        "uuid": "^3.0.0"
+      }
+    },
+    "http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "requires": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+      "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-data-descriptor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+      "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.0"
+      }
+    },
+    "is-descriptor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+      "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^1.0.0",
+        "is-data-descriptor": "^1.0.0",
+        "kind-of": "^6.0.2"
+      }
+    },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-port-reachable": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-3.1.0.tgz",
+      "integrity": "sha512-vjc0SSRNZ32s9SbZBzGaiP6YVB+xglLShhgZD/FHMZUXBvQWaV9CtzgeVhjccFJrI6RAMV+LX7NYxueW/A8W5A==",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha512-gfygJYZ2gLTDlmbWMI0CE2MwnFzSN/2SZfkMlItC4K/JBlsWVDB0bO6XhqcY13YXE7iMcAJnzTCJjPiTeJJ0Mw==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
+    "live-server": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.2.2.tgz",
+      "integrity": "sha512-t28HXLjITRGoMSrCOv4eZ88viHaBVIjKjdI5PO92Vxlu+twbk6aE0t7dVIaz6ZWkjPilYFV6OSdMYl9ybN2B4w==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^2.0.4",
+        "colors": "1.4.0",
+        "connect": "^3.6.6",
+        "cors": "^2.8.5",
+        "event-stream": "3.3.4",
+        "faye-websocket": "0.11.x",
+        "http-auth": "3.1.x",
+        "morgan": "^1.9.1",
+        "object-assign": "^4.1.1",
+        "opn": "^6.0.0",
+        "proxy-middleware": "^0.15.0",
+        "send": "^0.18.0",
+        "serve-index": "^1.9.1"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+              "dev": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "cors": {
+          "version": "2.8.5",
+          "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+          "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4",
+            "vary": "^1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+          "integrity": "sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha512-9fRVlXc0uCxEDj1nQzaWONSpbTfx0FmJfzHF7pwlI8DkWGoHBBea4Pg5Ky0ojwwxQmnSifgbKkI06Qv0Ljgj+Q==",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+          "dev": true
+        },
+        "on-finished": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+          "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+          "dev": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "opn": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-6.0.0.tgz",
+          "integrity": "sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        },
+        "proxy-middleware": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+          "integrity": "sha512-EGCG8SeoIRVMhsqHQUdDigB2i7qU7fCsWASwn54+nPutYO8n4q6EiwMzyfWlC+dzRFExP+kvcnDFdBDHoZBU7Q==",
+          "dev": true
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "send": {
+          "version": "0.18.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+          "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "2.0.0",
+            "destroy": "1.2.0",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "2.0.0",
+            "mime": "1.6.0",
+            "ms": "2.1.3",
+            "on-finished": "2.4.1",
+            "range-parser": "~1.2.1",
+            "statuses": "2.0.1"
+          }
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      }
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "integrity": "sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "dev": true
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+          "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        }
+      }
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        }
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "dev": true
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+          "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+          "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          }
+        },
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+          "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+          "dev": true
+        }
+      }
+    },
+    "unix-crypt-td-js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
+      "integrity": "sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+      "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+      "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "dev": true
+    }
+  }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/package.json
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "docs",
+  "version": "0.0.1",
+  "scripts": {
+    "docs": "oz-docs -c .",
+    "docs:watch": "npm run docs watch",
+    "prepare-docs": ""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@openzeppelin/docs-utils": "^0.1.2"
+  }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/netlify.toml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+base = "docs/"
+command = "npm run docs"
+publish = "build/site"

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/pyproject.toml
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+# AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
+requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# See configuration details in https://github.com/pypa/setuptools_scm
+version_scheme = "no-guess-dev"

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/scripts/update_version.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/scripts/update_version.py
@@ -1,0 +1,33 @@
+import fileinput
+import itertools
+import sys
+from pathlib import Path
+
+CURRENT_VERSION = "v0.6.1"
+OTHER_PATHS = ["docs/antora.yml", "README.md"]
+
+
+def main():
+    new_version = str(sys.argv[1])
+    src_path = Path("src")
+    docs_path = Path("docs")
+    for p in itertools.chain(
+        src_path.glob("**/*.cairo"),
+        docs_path.glob("**/*.adoc"), OTHER_PATHS):
+        _update_version(p, new_version)
+    _update_version("scripts/update_version.py", new_version)
+
+
+def _update_version(path, version):
+    with fileinput.input(path, inplace=True) as file:
+        for line in file:
+            old, new = CURRENT_VERSION, version
+            if path in OTHER_PATHS:
+                old = old.strip("v")
+                new = new.strip("v")
+            new_line = line.replace(old, new)
+            print(new_line, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/setup.cfg
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/setup.cfg
@@ -1,0 +1,37 @@
+[metadata]
+name = openzeppelin-cairo-contracts
+version = attr: openzeppelin.__version__
+description = Library for secure smart contract development written in Cairo
+author = OpenZeppelin Community
+author_email = maintainers@openzeppelin.org
+license = MIT
+long_description = file: README.md
+long_description_content_type = text/markdown; charset=UTF-8
+url = https://github.com/OpenZeppelin/cairo-contracts
+platforms = any
+classifiers =
+    Operating System :: OS Independent
+
+[options]
+zip_safe = False
+packages = find_namespace:
+include_package_data = True
+package_dir =
+    =src
+
+install_requires =
+    importlib-metadata>=4.0
+
+[options.packages.find]
+where = src
+exclude =
+    tests
+
+[options.package_data]
+openzeppelin = "*.cairo"
+
+[options.extras_require]
+testing =
+    setuptools
+    tox
+    pytest

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/setup.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+    try:
+        setup(use_scm_version={"version_scheme": "no-guess-dev"})
+    except:  # noqa
+        print(
+            "\n\nAn error occurred while building the project, "
+            "please ensure you have the most updated version of setuptools, "
+            "setuptools_scm and wheel with:\n"
+            "   pip install -U setuptools setuptools_scm wheel\n\n"
+        )
+        raise

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/__init__.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/__init__.py
@@ -1,0 +1,11 @@
+"""StarkNet/Cairo development toolbelt."""
+
+try:
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
+try:
+    __version__ = importlib_metadata.version("openzeppelin-cairo-contracts")
+except importlib_metadata.PackageNotFoundError:
+    __version__ = None

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/accesscontrol/IAccessControl.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/accesscontrol/IAccessControl.cairo
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/accesscontrol/IAccessControl.cairo)
+
+%lang starknet
+
+@contract_interface
+namespace IAccessControl {
+    func hasRole(role: felt, account: felt) -> (hasRole: felt) {
+    }
+
+    func getRoleAdmin(role: felt) -> (admin: felt) {
+    }
+
+    func grantRole(role: felt, account: felt) {
+    }
+
+    func revokeRole(role: felt, account: felt) {
+    }
+
+    func renounceRole(role: felt, account: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/accesscontrol/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/accesscontrol/library.cairo
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/accesscontrol/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.utils.constants.library import IACCESSCONTROL_ID
+
+//
+// Events
+//
+
+@event
+func RoleGranted(role: felt, account: felt, sender: felt) {
+}
+
+@event
+func RoleRevoked(role: felt, account: felt, sender: felt) {
+}
+
+@event
+func RoleAdminChanged(role: felt, previousAdminRole: felt, newAdminRole: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func AccessControl_role_admin(role: felt) -> (admin: felt) {
+}
+
+@storage_var
+func AccessControl_role_member(role: felt, account: felt) -> (has_role: felt) {
+}
+
+namespace AccessControl {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        ERC165.register_interface(IACCESSCONTROL_ID);
+        return ();
+    }
+
+    //
+    // Modifier
+    //
+
+    func assert_only_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt
+    ) {
+        alloc_locals;
+        let (caller) = get_caller_address();
+        let (authorized) = has_role(role, caller);
+        with_attr error_message("AccessControl: caller is missing role {role}") {
+            assert authorized = TRUE;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func has_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) -> (has_role: felt) {
+        return AccessControl_role_member.read(role, user);
+    }
+
+    func get_role_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt
+    ) -> (admin: felt) {
+        return AccessControl_role_admin.read(role);
+    }
+
+    //
+    // Externals
+    //
+
+    func grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (admin: felt) = get_role_admin(role);
+        assert_only_role(admin);
+        _grant_role(role, user);
+        return ();
+    }
+
+    func revoke_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (admin: felt) = get_role_admin(role);
+        assert_only_role(admin);
+        _revoke_role(role, user);
+        return ();
+    }
+
+    func renounce_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (caller: felt) = get_caller_address();
+        with_attr error_message("AccessControl: can only renounce roles for self") {
+            assert user = caller;
+        }
+        _revoke_role(role, user);
+        return ();
+    }
+
+    //
+    // Unprotected
+    //
+
+    func _grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (user_has_role: felt) = has_role(role, user);
+        if (user_has_role == FALSE) {
+            let (caller: felt) = get_caller_address();
+            AccessControl_role_member.write(role, user, TRUE);
+            RoleGranted.emit(role, user, caller);
+            return ();
+        }
+        return ();
+    }
+
+    func _revoke_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (user_has_role: felt) = has_role(role, user);
+        if (user_has_role == TRUE) {
+            let (caller: felt) = get_caller_address();
+            AccessControl_role_member.write(role, user, FALSE);
+            RoleRevoked.emit(role, user, caller);
+            return ();
+        }
+        return ();
+    }
+
+    func _set_role_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, admin_role: felt
+    ) {
+        let (previous_admin_role: felt) = get_role_admin(role);
+        AccessControl_role_admin.write(role, admin_role);
+        RoleAdminChanged.emit(role, previous_admin_role, admin_role);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/ownable/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/access/ownable/library.cairo
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/ownable/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero
+
+//
+// Events
+//
+
+@event
+func OwnershipTransferred(previousOwner: felt, newOwner: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func Ownable_owner() -> (owner: felt) {
+}
+
+namespace Ownable {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) {
+        _transfer_ownership(owner);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (owner) = Ownable.owner();
+        let (caller) = get_caller_address();
+        with_attr error_message("Ownable: caller is the zero address") {
+            assert_not_zero(caller);
+        }
+        with_attr error_message("Ownable: caller is not the owner") {
+            assert owner = caller;
+        }
+        return ();
+    }
+
+    //
+    // Public
+    //
+
+    func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+        return Ownable_owner.read();
+    }
+
+    func transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_owner: felt
+    ) {
+        with_attr error_message("Ownable: new owner is the zero address") {
+            assert_not_zero(new_owner);
+        }
+        assert_only_owner();
+        _transfer_ownership(new_owner);
+        return ();
+    }
+
+    func renounce_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_only_owner();
+        _transfer_ownership(0);
+        return ();
+    }
+
+    //
+    // Internal
+    //
+
+    func _transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_owner: felt
+    ) {
+        let (previous_owner: felt) = Ownable.owner();
+        Ownable_owner.write(new_owner);
+        OwnershipTransferred.emit(previous_owner, new_owner);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/IAccount.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/IAccount.cairo
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (account/IAccount.cairo)
+
+%lang starknet
+
+from openzeppelin.account.library import AccountCallArray
+
+@contract_interface
+namespace IAccount {
+    func isValidSignature(
+        hash: felt,
+        signature_len: felt,
+        signature: felt*
+    ) -> (isValid: felt) {
+    }
+
+    func __validate__(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*
+    ) {
+    }
+
+    // Parameter temporarily named `cls_hash` instead of `class_hash` (expected).
+    // See https://github.com/starkware-libs/cairo-lang/issues/100 for details.
+    func __validate_declare__(cls_hash: felt) {
+    }
+
+    func __execute__(
+        call_array_len: felt,
+        call_array: AccountCallArray*,
+        calldata_len: felt,
+        calldata: felt*
+    ) -> (
+        response_len: felt,
+        response: felt*
+    ) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/library.cairo
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (account/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.signature import verify_ecdsa_signature
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.math import split_felt
+from starkware.cairo.common.math_cmp import is_le_felt
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.starknet.common.syscalls import (
+    call_contract,
+    get_caller_address,
+    get_contract_address,
+    get_tx_info
+)
+from starkware.cairo.common.cairo_secp.signature import (
+    finalize_keccak,
+    verify_eth_signature_uint256
+)
+from openzeppelin.utils.constants.library import (
+    IACCOUNT_ID,
+    IERC165_ID,
+    TRANSACTION_VERSION
+)
+
+//
+// Storage
+//
+
+@storage_var
+func Account_public_key() -> (public_key: felt) {
+}
+
+//
+// Structs
+//
+
+struct Call {
+    to: felt,
+    selector: felt,
+    calldata_len: felt,
+    calldata: felt*,
+}
+
+// Tmp struct introduced while we wait for Cairo
+// to support passing `[AccountCall]` to __execute__
+struct AccountCallArray {
+    to: felt,
+    selector: felt,
+    data_offset: felt,
+    data_len: felt,
+}
+
+namespace Account {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        _public_key: felt
+    ) {
+        Account_public_key.write(_public_key);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_self{syscall_ptr: felt*}() {
+        let (self) = get_contract_address();
+        let (caller) = get_caller_address();
+        with_attr error_message("Account: caller is not this account") {
+            assert self = caller;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func get_public_key{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        public_key: felt
+    ) {
+        return Account_public_key.read();
+    }
+
+    func supports_interface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(interface_id: felt) -> (
+        success: felt
+    ) {
+        if (interface_id == IERC165_ID) {
+            return (success=TRUE);
+        }
+        if (interface_id == IACCOUNT_ID) {
+            return (success=TRUE);
+        }
+        return (success=FALSE);
+    }
+
+    //
+    // Setters
+    //
+
+    func set_public_key{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_public_key: felt
+    ) {
+        assert_only_self();
+        Account_public_key.write(new_public_key);
+        return ();
+    }
+
+    //
+    // Business logic
+    //
+
+    func is_valid_signature{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        ecdsa_ptr: SignatureBuiltin*,
+        range_check_ptr,
+    }(hash: felt, signature_len: felt, signature: felt*) -> (is_valid: felt) {
+        let (_public_key) = Account_public_key.read();
+
+        // This interface expects a signature pointer and length to make
+        // no assumption about signature validation schemes.
+        // But this implementation does, and it expects a (sig_r, sig_s) pair.
+        let sig_r = signature[0];
+        let sig_s = signature[1];
+
+        verify_ecdsa_signature(
+            message=hash, public_key=_public_key, signature_r=sig_r, signature_s=sig_s
+        );
+
+        return (is_valid=TRUE);
+    }
+
+    func is_valid_eth_signature{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        bitwise_ptr: BitwiseBuiltin*,
+        range_check_ptr,
+    }(hash: felt, signature_len: felt, signature: felt*) -> (is_valid: felt) {
+        alloc_locals;
+        let (_public_key) = get_public_key();
+        let (__fp__, _) = get_fp_and_pc();
+
+        // This interface expects a signature pointer and length to make
+        // no assumption about signature validation schemes.
+        // But this implementation does, and it expects a the sig_v, sig_r,
+        // sig_s, and hash elements.
+        let sig_v: felt = signature[0];
+        let sig_r: Uint256 = Uint256(low=signature[1], high=signature[2]);
+        let sig_s: Uint256 = Uint256(low=signature[3], high=signature[4]);
+        let (high, low) = split_felt(hash);
+        let msg_hash: Uint256 = Uint256(low=low, high=high);
+
+        let (keccak_ptr: felt*) = alloc();
+        local keccak_ptr_start: felt* = keccak_ptr;
+
+        with keccak_ptr {
+            verify_eth_signature_uint256(
+                msg_hash=msg_hash, r=sig_r, s=sig_s, v=sig_v, eth_address=_public_key
+            );
+        }
+        // Required to ensure sequencers cannot spoof validation check.
+        finalize_keccak(keccak_ptr_start=keccak_ptr_start, keccak_ptr_end=keccak_ptr);
+
+        return (is_valid=TRUE);
+    }
+
+    func execute{
+        syscall_ptr: felt*,
+        pedersen_ptr: HashBuiltin*,
+        ecdsa_ptr: SignatureBuiltin*,
+        bitwise_ptr: BitwiseBuiltin*,
+        range_check_ptr,
+    }(call_array_len: felt, call_array: AccountCallArray*, calldata_len: felt, calldata: felt*) -> (
+        response_len: felt, response: felt*
+    ) {
+        alloc_locals;
+
+        let (tx_info) = get_tx_info();
+        // Disallow deprecated tx versions
+        with_attr error_message("Account: deprecated tx version") {
+            assert is_le_felt(TRANSACTION_VERSION, tx_info.version) = TRUE;
+        }
+
+        // Assert not a reentrant call
+        let (caller) = get_caller_address();
+        with_attr error_message("Account: reentrant call") {
+            assert caller = 0;
+        }
+
+        // TMP: Convert `AccountCallArray` to 'Call'.
+        let (calls: Call*) = alloc();
+        _from_call_array_to_call(call_array_len, call_array, calldata, calls);
+        let calls_len = call_array_len;
+
+        // Execute call
+        let (response: felt*) = alloc();
+        let (response_len) = _execute_list(calls_len, calls, response);
+
+        return (response_len=response_len, response=response);
+    }
+
+    func _execute_list{syscall_ptr: felt*}(calls_len: felt, calls: Call*, response: felt*) -> (
+        response_len: felt
+    ) {
+        alloc_locals;
+
+        // if no more calls
+        if (calls_len == 0) {
+            return (response_len=0);
+        }
+
+        // do the current call
+        let this_call: Call = [calls];
+        let res = call_contract(
+            contract_address=this_call.to,
+            function_selector=this_call.selector,
+            calldata_size=this_call.calldata_len,
+            calldata=this_call.calldata,
+        );
+        // copy the result in response
+        memcpy(response, res.retdata, res.retdata_size);
+        // do the next calls recursively
+        let (response_len) = _execute_list(
+            calls_len - 1, calls + Call.SIZE, response + res.retdata_size
+        );
+        return (response_len=response_len + res.retdata_size);
+    }
+
+    func _from_call_array_to_call{syscall_ptr: felt*}(
+        call_array_len: felt, call_array: AccountCallArray*, calldata: felt*, calls: Call*
+    ) {
+        // if no more calls
+        if (call_array_len == 0) {
+            return ();
+        }
+
+        // parse the current call
+        assert [calls] = Call(
+            to=[call_array].to,
+            selector=[call_array].selector,
+            calldata_len=[call_array].data_len,
+            calldata=calldata + [call_array].data_offset
+            );
+        // parse the remaining calls recursively
+        _from_call_array_to_call(
+            call_array_len - 1, call_array + AccountCallArray.SIZE, calldata, calls + Call.SIZE
+        );
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/Account.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/Account.cairo
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (account/presets/Account.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
+from starkware.starknet.common.syscalls import get_tx_info
+
+from openzeppelin.account.library import Account, AccountCallArray
+
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}(publicKey: felt) {
+    Account.initializer(publicKey);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func getPublicKey{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} () -> (publicKey: felt) {
+    let (publicKey: felt) = Account.get_public_key();
+    return (publicKey=publicKey);
+}
+
+@view
+func supportsInterface{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} (interfaceId: felt) -> (success: felt) {
+    return Account.supports_interface(interfaceId);
+}
+
+//
+// Setters
+//
+
+@external
+func setPublicKey{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} (newPublicKey: felt) {
+    Account.set_public_key(newPublicKey);
+    return ();
+}
+
+//
+// Business logic
+//
+
+@view
+func isValidSignature{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+}(
+    hash: felt,
+    signature_len: felt,
+    signature: felt*
+) -> (isValid: felt) {
+    let (isValid: felt) = Account.is_valid_signature(hash, signature_len, signature);
+    return (isValid=isValid);
+}
+
+@external
+func __validate__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@external
+func __validate_declare__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+} (class_hash: felt) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@external
+func __validate_deploy__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    range_check_ptr
+} (
+    class_hash: felt,
+    salt: felt,
+    publicKey: felt
+) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@external
+func __execute__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr,
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) -> (
+    response_len: felt,
+    response: felt*
+) {
+    let (response_len, response) = Account.execute(
+        call_array_len, call_array, calldata_len, calldata
+    );
+    return (response_len, response);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/AddressRegistry.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/AddressRegistry.cairo
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (account/presets/AddressRegistry.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+@storage_var
+func L1_address(L2_address: felt) -> (address: felt) {
+}
+
+@external
+func get_L1_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    L2_address: felt
+) -> (address: felt) {
+    return L1_address.read(L2_address);
+}
+
+@external
+func set_L1_address{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    new_L1_address: felt
+) {
+    let (caller) = get_caller_address();
+    L1_address.write(caller, new_L1_address);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/EthAccount.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/account/presets/EthAccount.cairo
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (account/presets/EthAccount.cairo)
+
+%lang starknet
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin, BitwiseBuiltin
+from starkware.starknet.common.syscalls import get_tx_info
+
+from openzeppelin.account.library import Account, AccountCallArray
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}(ethAddress: felt) {
+    Account.initializer(ethAddress);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func getEthAddress{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} () -> (ethAddress: felt) {
+    let (ethAddress: felt) = Account.get_public_key();
+    return (ethAddress=ethAddress);
+}
+
+@view
+func supportsInterface{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} (interfaceId: felt) -> (success: felt) {
+    return Account.supports_interface(interfaceId);
+}
+
+//
+// Setters
+//
+
+@external
+func setEthAddress{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+} (newEthAddress: felt) {
+    Account.set_public_key(newEthAddress);
+    return ();
+}
+
+//
+// Business logic
+//
+
+@view
+func isValidSignature{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr,
+}(
+    hash: felt,
+    signature_len: felt,
+    signature: felt*
+) -> (isValid: felt) {
+    let (isValid) = Account.is_valid_eth_signature(hash, signature_len, signature);
+    return (isValid=isValid);
+}
+
+@external
+func __validate__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr,
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@external
+func __validate_declare__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr,
+} (class_hash: felt) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+
+@external
+func __validate_deploy__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr
+} (
+    class_hash: felt,
+    salt: felt,
+    ethAddress: felt
+) {
+    let (tx_info) = get_tx_info();
+    Account.is_valid_eth_signature(tx_info.transaction_hash, tx_info.signature_len, tx_info.signature);
+    return ();
+}
+
+@external
+func __execute__{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    ecdsa_ptr: SignatureBuiltin*,
+    bitwise_ptr: BitwiseBuiltin*,
+    range_check_ptr,
+}(
+    call_array_len: felt,
+    call_array: AccountCallArray*,
+    calldata_len: felt,
+    calldata: felt*
+) -> (
+    response_len: felt,
+    response: felt*
+) {
+    let (response_len, response) = Account.execute(
+        call_array_len, call_array, calldata_len, calldata
+    );
+    return (response_len, response);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/introspection/erc165/IERC165.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/introspection/erc165/IERC165.cairo
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (introspection/erc165/IERC165.cairo)
+
+%lang starknet
+
+@contract_interface
+namespace IERC165 {
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/introspection/erc165/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/introspection/erc165/library.cairo
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (introspection/erc165/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_equal
+from starkware.cairo.common.bool import TRUE
+
+from openzeppelin.utils.constants.library import INVALID_ID, IERC165_ID
+
+@storage_var
+func ERC165_supported_interfaces(interface_id: felt) -> (is_supported: felt) {
+}
+
+namespace ERC165 {
+    func supports_interface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        interface_id: felt
+    ) -> (success: felt) {
+        if (interface_id == IERC165_ID) {
+            return (success=TRUE);
+        }
+
+        // Checks interface registry
+        let (is_supported) = ERC165_supported_interfaces.read(interface_id);
+        return (success=is_supported);
+    }
+
+    func register_interface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        interface_id: felt
+    ) {
+        with_attr error_message("ERC165: invalid interface id") {
+            assert_not_equal(interface_id, INVALID_ID);
+        }
+        ERC165_supported_interfaces.write(interface_id, TRUE);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/initializable/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/initializable/library.cairo
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/initializable/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+@storage_var
+func Initializable_initialized() -> (initialized: felt) {
+}
+
+namespace Initializable {
+    func initialized{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        felt
+    ) {
+        return Initializable_initialized.read();
+    }
+
+    func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_initialized) = Initializable_initialized.read();
+        with_attr error_message("Initializable: contract already initialized") {
+            assert is_initialized = FALSE;
+        }
+        Initializable_initialized.write(TRUE);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/pausable/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/pausable/library.cairo
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/pausable/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+//
+// Storage
+//
+
+@storage_var
+func Pausable_paused() -> (paused: felt) {
+}
+
+//
+// Events
+//
+
+@event
+func Paused(account: felt) {
+}
+
+@event
+func Unpaused(account: felt) {
+}
+
+namespace Pausable {
+    func is_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        paused: felt
+    ) {
+        return Pausable_paused.read();
+    }
+
+    func assert_not_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_paused) = Pausable_paused.read();
+        with_attr error_message("Pausable: paused") {
+            assert is_paused = FALSE;
+        }
+        return ();
+    }
+
+    func assert_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_paused) = Pausable_paused.read();
+        with_attr error_message("Pausable: not paused") {
+            assert is_paused = TRUE;
+        }
+        return ();
+    }
+
+    func _pause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_not_paused();
+        Pausable_paused.write(TRUE);
+
+        let (account) = get_caller_address();
+        Paused.emit(account);
+        return ();
+    }
+
+    func _unpause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_paused();
+        Pausable_paused.write(FALSE);
+
+        let (account) = get_caller_address();
+        Unpaused.emit(account);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/reentrancyguard/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/reentrancyguard/library.cairo
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/reentrancyguard/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+@storage_var
+func ReentrancyGuard_entered() -> (entered: felt) {
+}
+
+namespace ReentrancyGuard {
+    func start{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (has_entered) = ReentrancyGuard_entered.read();
+        with_attr error_message("ReentrancyGuard: reentrant call") {
+            assert has_entered = FALSE;
+        }
+        ReentrancyGuard_entered.write(TRUE);
+        return ();
+    }
+
+    func end{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        ReentrancyGuard_entered.write(FALSE);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/safemath/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/security/safemath/library.cairo
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/safemath/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_check,
+    uint256_add,
+    uint256_sub,
+    uint256_mul,
+    uint256_unsigned_div_rem,
+    uint256_le,
+    uint256_lt,
+    uint256_eq,
+)
+
+namespace SafeUint256 {
+    // Adds two integers.
+    // Reverts if the sum overflows.
+    func add{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        uint256_check(a);
+        uint256_check(b);
+        let (c: Uint256, is_overflow) = uint256_add(a, b);
+        with_attr error_message("SafeUint256: addition overflow") {
+            assert is_overflow = FALSE;
+        }
+        return (c=c);
+    }
+
+    // Subtracts two integers.
+    // Reverts if subtrahend (`b`) is greater than minuend (`a`).
+    func sub_le{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+        let (is_le) = uint256_le(b, a);
+        with_attr error_message("SafeUint256: subtraction overflow") {
+            assert is_le = TRUE;
+        }
+        let (c: Uint256) = uint256_sub(a, b);
+        return (c=c);
+    }
+
+    // Subtracts two integers.
+    // Reverts if subtrahend (`b`) is greater than or equal to minuend (`a`).
+    func sub_lt{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+
+        let (is_lt) = uint256_lt(b, a);
+        with_attr error_message("SafeUint256: subtraction overflow or the difference equals zero") {
+            assert is_lt = TRUE;
+        }
+        let (c: Uint256) = uint256_sub(a, b);
+        return (c=c);
+    }
+
+    // Multiplies two integers.
+    // Reverts if product is greater than 2^256.
+    func mul{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+        let (a_zero) = uint256_eq(a, Uint256(0, 0));
+        if (a_zero == TRUE) {
+            return (c=a);
+        }
+
+        let (b_zero) = uint256_eq(b, Uint256(0, 0));
+        if (b_zero == TRUE) {
+            return (c=b);
+        }
+
+        let (c: Uint256, overflow: Uint256) = uint256_mul(a, b);
+        with_attr error_message("SafeUint256: multiplication overflow") {
+            assert overflow = Uint256(0, 0);
+        }
+        return (c=c);
+    }
+
+    // Integer division of two numbers. Returns uint256 quotient and remainder.
+    // Reverts if divisor is zero as per OpenZeppelin's Solidity implementation.
+    // Cairo's `uint256_unsigned_div_rem` already checks:
+    //    remainder < divisor
+    //    quotient * divisor + remainder == dividend
+    func div_rem{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+
+        let (is_zero) = uint256_eq(b, Uint256(0, 0));
+        with_attr error_message("SafeUint256: divisor cannot be zero") {
+            assert is_zero = FALSE;
+        }
+
+        let (c: Uint256, rem: Uint256) = uint256_unsigned_div_rem(a, b);
+        return (c=c, rem=rem);
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155.cairo
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155 {
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(
+        accounts_len: felt,
+        accounts: felt*,
+        ids_len: felt,
+        ids: Uint256*
+    ) -> (
+        balances_len: felt,
+        balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt,
+        to: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155MetadataURI.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155MetadataURI.cairo
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155MetadataURI.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155MetadataURI {
+    func uri(id: Uint256) -> (uri: felt) {
+    }
+
+    // ERC1155
+
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*) -> (
+        balances_len: felt, balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155Receiver.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/IERC1155Receiver.cairo
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155Receiver.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155Receiver {
+    func onERC1155Received(
+        operator: felt,
+        from_: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (selector: felt) {
+    }
+
+    func onERC1155BatchReceived(
+        operator: felt,
+        from_: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) -> (selector: felt) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/library.cairo
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero, assert_not_equal
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.uint256 import Uint256, uint256_check
+from starkware.cairo.common.bool import TRUE
+
+from openzeppelin.introspection.erc165.IERC165 import IERC165
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.token.erc1155.IERC1155Receiver import IERC1155Receiver
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.utils.constants.library import (
+    IERC1155_ID,
+    IERC1155_METADATA_ID,
+    IERC1155_RECEIVER_ID,
+    IACCOUNT_ID,
+    ON_ERC1155_RECEIVED_SELECTOR,
+    ON_ERC1155_BATCH_RECEIVED_SELECTOR,
+)
+
+//
+// Events
+//
+
+@event
+func TransferSingle(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    id: Uint256,
+    value: Uint256
+) {
+}
+
+@event
+func TransferBatch(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+) {
+}
+
+@event
+func ApprovalForAll(account: felt, operator: felt, approved: felt) {
+}
+
+@event
+func URI(value: felt, id: Uint256) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func ERC1155_balances(id: Uint256, account: felt) -> (balance: Uint256) {
+}
+
+@storage_var
+func ERC1155_operator_approvals(account: felt, operator: felt) -> (approved: felt) {
+}
+
+@storage_var
+func ERC1155_uri() -> (uri: felt) {
+}
+
+namespace ERC1155 {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(uri: felt) {
+        _set_uri(uri);
+        ERC165.register_interface(IERC1155_ID);
+        ERC165.register_interface(IERC1155_METADATA_ID);
+        return ();
+    }
+
+    //
+    // Modifiers
+    //
+
+    func assert_owner_or_approved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt
+    ) {
+        let (caller) = get_caller_address();
+        if (caller == owner) {
+            return ();
+        }
+        let (approved) = ERC1155.is_approved_for_all(owner, caller);
+        with_attr error_message("ERC1155: caller is not owner nor approved") {
+            assert approved = TRUE;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    // This implementation returns the same URI for *all* token types. It relies
+    // on the token type ID substitution mechanism
+    // https://eips.ethereum.org/EIPS/eip-1155#metadata[defined in the EIP].
+    //
+    // Clients calling this function must replace the `\{id\}` substring with the
+    // actual token type ID.
+    func uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: Uint256) -> (
+        uri: felt
+    ) {
+        return ERC1155_uri.read();
+    }
+
+    func balance_of{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt, id: Uint256
+    ) -> (balance: Uint256) {
+        with_attr error_message("ERC1155: address zero is not a valid owner") {
+            assert_not_zero(account);
+        }
+        _check_id(id);
+        return ERC1155_balances.read(id, account);
+    }
+
+    func balance_of_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*
+    ) -> (balances_len: felt, balances: Uint256*) {
+        alloc_locals;
+        // Check args are equal length arrays
+        with_attr error_message("ERC1155: accounts and ids length mismatch") {
+            assert ids_len = accounts_len;
+        }
+        // Allocate memory
+        let (local balances: Uint256*) = alloc();
+        // Call iterator
+        _balance_of_batch_iter(accounts_len, accounts, ids, balances);
+        return (accounts_len, balances);
+    }
+
+    func is_approved_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt, operator: felt
+    ) -> (approved: felt) {
+        return ERC1155_operator_approvals.read(account, operator);
+    }
+
+    //
+    // Externals
+    //
+
+    func set_approval_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        operator: felt, approved: felt
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot approve from the zero address") {
+            assert_not_zero(caller);
+        }
+        _set_approval_for_all(caller, operator, approved);
+        return ();
+    }
+
+    func safe_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot call transfer from the zero address") {
+            assert_not_zero(caller);
+        }
+        assert_owner_or_approved(from_);
+        _safe_transfer_from(from_, to, id, value, data_len, data);
+        return ();
+    }
+
+    func safe_batch_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot call transfer from the zero address") {
+            assert_not_zero(caller);
+        }
+        assert_owner_or_approved(from_);
+        _safe_batch_transfer_from(from_, to, ids_len, ids, values_len, values, data_len, data);
+        return ();
+    }
+
+    //
+    // Internals
+    //
+
+    func _safe_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        alloc_locals;
+        // Validate input
+        with_attr error_message("ERC1155: transfer to the zero address") {
+            assert_not_zero(to);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Deduct from sender
+        let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+        with_attr error_message("ERC1155: insufficient balance for transfer") {
+            let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+        }
+        ERC1155_balances.write(id, from_, new_balance);
+
+        // Add to receiver
+        _add_to_receiver(id, value, to);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator, from_, to, id, value);
+
+        _do_safe_transfer_acceptance_check(operator, from_, to, id, value, data_len, data);
+        return ();
+    }
+
+    func _safe_batch_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        alloc_locals;
+        // Check args
+        with_attr error_message("ERC1155: transfer to the zero address") {
+            assert_not_zero(to);
+        }
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+        // Recursive call
+        _safe_batch_transfer_from_iter(from_, to, ids_len, ids, values);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferBatch.emit(operator, from_, to, ids_len, ids, values_len, values);
+
+        _do_safe_batch_transfer_acceptance_check(
+            operator, from_, to, ids_len, ids, values_len, values, data_len, data
+        );
+        return ();
+    }
+
+    func _mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        // Validate input
+        with_attr error_message("ERC1155: mint to the zero address") {
+            assert_not_zero(to);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Add to minter, check for overflow
+        _add_to_receiver(id, value, to);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator=operator, from_=0, to=to, id=id, value=value);
+        _do_safe_transfer_acceptance_check(
+            operator=operator, from_=0, to=to, id=id, value=value, data_len=data_len, data=data
+        );
+        return ();
+    }
+
+    func _mint_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        alloc_locals;
+        // Cannot mint to zero address
+        with_attr error_message("ERC1155: mint to the zero address") {
+            assert_not_zero(to);
+        }
+        // Check args are equal length arrays
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+
+        // Recursive call
+        _mint_batch_iter(to, ids_len, ids, values);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferBatch.emit(
+            operator=operator,
+            from_=0,
+            to=to,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+        );
+        _do_safe_batch_transfer_acceptance_check(
+            operator=operator,
+            from_=0,
+            to=to,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+            data_len=data_len,
+            data=data,
+        );
+        return ();
+    }
+
+    func _burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, id: Uint256, value: Uint256
+    ) {
+        alloc_locals;
+        // Validate input
+        with_attr error_message("ERC1155: burn from the zero address") {
+            assert_not_zero(from_);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Deduct from burner
+        let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+        with_attr error_message("ERC1155: burn value exceeds balance") {
+            let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+        }
+
+        ERC1155_balances.write(id, from_, new_balance);
+
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator=operator, from_=from_, to=0, id=id, value=value);
+        return ();
+    }
+
+    func _burn_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, ids_len: felt, ids: Uint256*, values_len: felt, values: Uint256*
+    ) {
+        alloc_locals;
+        with_attr error_message("ERC1155: burn from the zero address") {
+            assert_not_zero(from_);
+        }
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+
+        // Recursive call
+        _burn_batch_iter(from_, ids_len, ids, values);
+        let (operator) = get_caller_address();
+        TransferBatch.emit(
+            operator=operator,
+            from_=from_,
+            to=0,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+        );
+        return ();
+    }
+
+    func _set_approval_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, operator: felt, approved: felt
+    ) {
+        // check approved is bool
+        with_attr error_message("ERC1155: approval is not boolean") {
+            assert approved * (approved - 1) = 0;
+        }
+
+        // caller/owner already checked non-0
+        with_attr error_message("ERC1155: setting approval status for zero address") {
+            assert_not_zero(operator);
+        }
+
+        with_attr error_message("ERC1155: setting approval status for self") {
+            assert_not_equal(owner, operator);
+        }
+
+        ERC1155_operator_approvals.write(owner, operator, approved);
+        ApprovalForAll.emit(owner, operator, approved);
+        return ();
+    }
+
+    func _set_uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(uri: felt) {
+        ERC1155_uri.write(uri);
+        return ();
+    }
+}
+
+//
+// Private
+//
+
+func _do_safe_transfer_acceptance_check{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(
+    operator: felt, from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    // Confirm supports IERC1155receiver interface
+    let (is_supported) = IERC165.supportsInterface(to, IERC1155_RECEIVER_ID);
+    if (is_supported == TRUE) {
+        let (selector) = IERC1155Receiver.onERC1155Received(
+            to, operator, from_, id, value, data_len, data
+        );
+
+        // Confirm onERC1155Recieved selector returned
+        with_attr error_message("ERC1155: ERC1155Receiver rejected tokens") {
+            assert selector = ON_ERC1155_RECEIVED_SELECTOR;
+        }
+        return ();
+    }
+
+    // Alternatively confirm account
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID);
+    with_attr error_message("ERC1155: transfer to non-ERC1155Receiver implementer") {
+        assert is_account = TRUE;
+    }
+    return ();
+}
+
+func _do_safe_batch_transfer_acceptance_check{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    // Confirm supports IERC1155receiver interface
+    let (is_supported) = IERC165.supportsInterface(to, IERC1155_RECEIVER_ID);
+    if (is_supported == TRUE) {
+        let (selector) = IERC1155Receiver.onERC1155BatchReceived(
+            contract_address=to,
+            operator=operator,
+            from_=from_,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+            data_len=data_len,
+            data=data,
+        );
+        // Confirm onBatchERC1155Recieved selector returned
+        with_attr error_message("ERC1155: ERC1155Receiver rejected tokens") {
+            assert selector = ON_ERC1155_BATCH_RECEIVED_SELECTOR;
+        }
+        return ();
+    }
+
+    // Alternatively confirm account
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID);
+    with_attr error_message("ERC1155: transfer to non-ERC1155Receiver implementer") {
+        assert is_account = TRUE;
+    }
+    return ();
+}
+
+func _balance_of_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    len: felt, accounts: felt*, ids: Uint256*, batch_balances: Uint256*
+) {
+    if (len == 0) {
+        return ();
+    }
+    // Read current entries
+    let id: Uint256 = [ids];
+    _check_id(id);
+    let account: felt = [accounts];
+
+    // Get balance
+    let (balance: Uint256) = ERC1155.balance_of(account, id);
+    assert [batch_balances] = balance;
+    return _balance_of_batch_iter(
+        len - 1, accounts + 1, ids + Uint256.SIZE, batch_balances + Uint256.SIZE
+    );
+}
+
+func _safe_batch_transfer_from_iter{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(from_: felt, to: felt, len: felt, ids: Uint256*, values: Uint256*) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries, perform Uint256 checks
+    let id = [ids];
+    let value = [values];
+    _check_id(id);
+    _check_value(value);
+
+    // deduct from sender
+    let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+    with_attr error_message("ERC1155: insufficient balance for transfer") {
+        let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+    }
+    ERC1155_balances.write(id, from_, new_balance);
+
+    _add_to_receiver(id, value, to);
+
+    // Recursive call
+    return _safe_batch_transfer_from_iter(
+        from_, to, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE
+    );
+}
+
+func _mint_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, len: felt, ids: Uint256*, values: Uint256*
+) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries
+    let id: Uint256 = [ids];
+    let value: Uint256 = [values];
+    _check_id(id);
+    _check_value(value);
+
+    _add_to_receiver(id, value, to);
+
+    // Recursive call
+    return _mint_batch_iter(to, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE);
+}
+
+func _burn_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, len: felt, ids: Uint256*, values: Uint256*
+) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries
+    let id: Uint256 = [ids];
+    let value: Uint256 = [values];
+    _check_id(id);
+    _check_value(value);
+
+    // Deduct from burner
+    let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+    with_attr error_message("ERC1155: burn value exceeds balance") {
+        let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+    }
+    ERC1155_balances.write(id, from_, new_balance);
+
+    // Recursive call
+    return _burn_batch_iter(from_, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE);
+}
+
+func _add_to_receiver{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    id: Uint256, value: Uint256, receiver: felt
+) {
+    let (receiver_balance: Uint256) = ERC1155_balances.read(id, receiver);
+    with_attr error_message("ERC1155: balance overflow") {
+        let (new_balance: Uint256) = SafeUint256.add(receiver_balance, value);
+    }
+    ERC1155_balances.write(id, receiver, new_balance);
+    return ();
+}
+
+func _check_id{range_check_ptr}(id: Uint256) {
+    with_attr error_message("ERC1155: token_id is not a valid Uint256") {
+        uint256_check(id);
+    }
+    return ();
+}
+
+func _check_value{range_check_ptr}(value: Uint256) {
+    with_attr error_message("ERC1155: value is not a valid Uint256") {
+        uint256_check(value);
+    }
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/presets/ERC1155MintableBurnable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/presets/ERC1155MintableBurnable.cairo
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/presets/ERC1155MintableBurnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.token.erc1155.library import ERC1155
+from openzeppelin.introspection.erc165.library import ERC165
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    uri: felt, owner: felt
+) {
+    ERC1155.initializer(uri);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@view
+func uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: Uint256) -> (
+    uri: felt
+) {
+    return ERC1155.uri(id);
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, id: Uint256
+) -> (balance: Uint256) {
+    return ERC1155.balance_of(account, id);
+}
+
+@view
+func balanceOfBatch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*
+) -> (balances_len: felt, balances: Uint256*) {
+    return ERC1155.balance_of_batch(accounts_len, accounts, ids_len, ids);
+}
+
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, operator: felt
+) -> (approved: felt) {
+    return ERC1155.is_approved_for_all(account, operator);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    ERC1155.set_approval_for_all(operator, approved);
+    return ();
+}
+
+@external
+func safeTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    ERC1155.safe_transfer_from(from_, to, id, value, data_len, data);
+    return ();
+}
+
+@external
+func safeBatchTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    ERC1155.safe_batch_transfer_from(from_, to, ids_len, ids, values_len, values, data_len, data);
+    return ();
+}
+
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    Ownable.assert_only_owner();
+    ERC1155._mint(to, id, value, data_len, data);
+    return ();
+}
+
+@external
+func mintBatch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    Ownable.assert_only_owner();
+    ERC1155._mint_batch(to, ids_len, ids, values_len, values, data_len, data);
+    return ();
+}
+
+@external
+func burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, id: Uint256, value: Uint256
+) {
+    ERC1155.assert_owner_or_approved(owner=from_);
+    ERC1155._burn(from_, id, value);
+    return ();
+}
+
+@external
+func burnBatch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, ids_len: felt, ids: Uint256*, values_len: felt, values: Uint256*
+) {
+    ERC1155.assert_owner_or_approved(owner=from_);
+    ERC1155._burn_batch(from_, ids_len, ids, values_len, values);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/presets/utils/ERC1155Holder.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc1155/presets/utils/ERC1155Holder.cairo
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/presets/utils/ERC1155Holder.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from openzeppelin.utils.constants.library import (
+    IERC1155_RECEIVER_ID,
+    ON_ERC1155_RECEIVED_SELECTOR,
+    ON_ERC1155_BATCH_RECEIVED_SELECTOR,
+)
+
+@view
+func onERC1155Received(
+    operator: felt, from_: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) -> (selector: felt) {
+    if (data_len == 0) {
+        return (ON_ERC1155_RECEIVED_SELECTOR,);
+    } else {
+        return (FALSE,);
+    }
+}
+
+@view
+func onERC1155BatchReceived(
+    operator: felt,
+    from_: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) -> (selector: felt) {
+    if (data_len == 0) {
+        return (ON_ERC1155_BATCH_RECEIVED_SELECTOR,);
+    } else {
+        return (FALSE,);
+    }
+}
+
+@view
+func supportsInterface(interfaceId: felt) -> (success: felt) {
+    if (interfaceId == IERC1155_RECEIVER_ID) {
+        return (TRUE,);
+    } else {
+        return (FALSE,);
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/IERC20.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/IERC20.cairo
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/IERC20.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC20 {
+    func name() -> (name: felt) {
+    }
+
+    func symbol() -> (symbol: felt) {
+    }
+
+    func decimals() -> (decimals: felt) {
+    }
+
+    func totalSupply() -> (totalSupply: Uint256) {
+    }
+
+    func balanceOf(account: felt) -> (balance: Uint256) {
+    }
+
+    func allowance(owner: felt, spender: felt) -> (remaining: Uint256) {
+    }
+
+    func transfer(recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func transferFrom(sender: felt, recipient: felt, amount: Uint256) -> (success: felt) {
+    }
+
+    func approve(spender: felt, amount: Uint256) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/library.cairo
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero, assert_le
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256, uint256_check, uint256_eq, uint256_not
+
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.utils.constants.library import UINT8_MAX
+
+//
+// Events
+//
+
+@event
+func Transfer(from_: felt, to: felt, value: Uint256) {
+}
+
+@event
+func Approval(owner: felt, spender: felt, value: Uint256) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func ERC20_name() -> (name: felt) {
+}
+
+@storage_var
+func ERC20_symbol() -> (symbol: felt) {
+}
+
+@storage_var
+func ERC20_decimals() -> (decimals: felt) {
+}
+
+@storage_var
+func ERC20_total_supply() -> (total_supply: Uint256) {
+}
+
+@storage_var
+func ERC20_balances(account: felt) -> (balance: Uint256) {
+}
+
+@storage_var
+func ERC20_allowances(owner: felt, spender: felt) -> (remaining: Uint256) {
+}
+
+namespace ERC20 {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        name: felt, symbol: felt, decimals: felt
+    ) {
+        ERC20_name.write(name);
+        ERC20_symbol.write(symbol);
+        with_attr error_message("ERC20: decimals exceed 2^8") {
+            assert_le(decimals, UINT8_MAX);
+        }
+        ERC20_decimals.write(decimals);
+        return ();
+    }
+
+    //
+    // Public functions
+    //
+
+    func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+        return ERC20_name.read();
+    }
+
+    func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        symbol: felt
+    ) {
+        return ERC20_symbol.read();
+    }
+
+    func total_supply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        total_supply: Uint256
+    ) {
+        return ERC20_total_supply.read();
+    }
+
+    func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        decimals: felt
+    ) {
+        return ERC20_decimals.read();
+    }
+
+    func balance_of{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt
+    ) -> (balance: Uint256) {
+        return ERC20_balances.read(account);
+    }
+
+    func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, spender: felt
+    ) -> (remaining: Uint256) {
+        return ERC20_allowances.read(owner, spender);
+    }
+
+    func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        recipient: felt, amount: Uint256
+    ) -> (success: felt) {
+        let (sender) = get_caller_address();
+        _transfer(sender, recipient, amount);
+        return (success=TRUE);
+    }
+
+    func transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        sender: felt, recipient: felt, amount: Uint256
+    ) -> (success: felt) {
+        let (caller) = get_caller_address();
+        _spend_allowance(sender, caller, amount);
+        _transfer(sender, recipient, amount);
+        return (success=TRUE);
+    }
+
+    func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        spender: felt, amount: Uint256
+    ) -> (success: felt) {
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);
+        }
+
+        let (caller) = get_caller_address();
+        _approve(caller, spender, amount);
+        return (success=TRUE);
+    }
+
+    func increase_allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        spender: felt, added_value: Uint256
+    ) -> (success: felt) {
+        with_attr error("ERC20: added_value is not a valid Uint256") {
+            uint256_check(added_value);
+        }
+
+        let (caller) = get_caller_address();
+        let (current_allowance: Uint256) = ERC20_allowances.read(caller, spender);
+
+        // add allowance
+        with_attr error_message("ERC20: allowance overflow") {
+            let (new_allowance: Uint256) = SafeUint256.add(current_allowance, added_value);
+        }
+
+        _approve(caller, spender, new_allowance);
+        return (success=TRUE);
+    }
+
+    func decrease_allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        spender: felt, subtracted_value: Uint256
+    ) -> (success: felt) {
+        alloc_locals;
+        with_attr error_message("ERC20: subtracted_value is not a valid Uint256") {
+            uint256_check(subtracted_value);
+        }
+
+        let (caller) = get_caller_address();
+        let (current_allowance: Uint256) = ERC20_allowances.read(owner=caller, spender=spender);
+
+        with_attr error_message("ERC20: allowance below zero") {
+            let (new_allowance: Uint256) = SafeUint256.sub_le(current_allowance, subtracted_value);
+        }
+
+        _approve(caller, spender, new_allowance);
+        return (success=TRUE);
+    }
+
+    //
+    // Internal
+    //
+
+    func _mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        recipient: felt, amount: Uint256
+    ) {
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);
+        }
+
+        with_attr error_message("ERC20: cannot mint to the zero address") {
+            assert_not_zero(recipient);
+        }
+
+        let (supply: Uint256) = ERC20_total_supply.read();
+        with_attr error_message("ERC20: mint overflow") {
+            let (new_supply: Uint256) = SafeUint256.add(supply, amount);
+        }
+        ERC20_total_supply.write(new_supply);
+
+        let (balance: Uint256) = ERC20_balances.read(account=recipient);
+        // overflow is not possible because sum is guaranteed to be less than total supply
+        // which we check for overflow below
+        let (new_balance: Uint256) = SafeUint256.add(balance, amount);
+        ERC20_balances.write(recipient, new_balance);
+
+        Transfer.emit(0, recipient, amount);
+        return ();
+    }
+
+    func _burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt, amount: Uint256
+    ) {
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);
+        }
+
+        with_attr error_message("ERC20: cannot burn from the zero address") {
+            assert_not_zero(account);
+        }
+
+        let (balance: Uint256) = ERC20_balances.read(account);
+        with_attr error_message("ERC20: burn amount exceeds balance") {
+            let (new_balance: Uint256) = SafeUint256.sub_le(balance, amount);
+        }
+
+        ERC20_balances.write(account, new_balance);
+
+        let (supply: Uint256) = ERC20_total_supply.read();
+        let (new_supply: Uint256) = SafeUint256.sub_le(supply, amount);
+        ERC20_total_supply.write(new_supply);
+        Transfer.emit(account, 0, amount);
+        return ();
+    }
+
+    func _transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        sender: felt, recipient: felt, amount: Uint256
+    ) {
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);  // almost surely not needed, might remove after confirmation
+        }
+
+        with_attr error_message("ERC20: cannot transfer from the zero address") {
+            assert_not_zero(sender);
+        }
+
+        with_attr error_message("ERC20: cannot transfer to the zero address") {
+            assert_not_zero(recipient);
+        }
+
+        let (sender_balance: Uint256) = ERC20_balances.read(account=sender);
+        with_attr error_message("ERC20: transfer amount exceeds balance") {
+            let (new_sender_balance: Uint256) = SafeUint256.sub_le(sender_balance, amount);
+        }
+
+        ERC20_balances.write(sender, new_sender_balance);
+
+        // add to recipient
+        let (recipient_balance: Uint256) = ERC20_balances.read(account=recipient);
+        // overflow is not possible because sum is guaranteed by mint to be less than total supply
+        let (new_recipient_balance: Uint256) = SafeUint256.add(recipient_balance, amount);
+        ERC20_balances.write(recipient, new_recipient_balance);
+        Transfer.emit(sender, recipient, amount);
+        return ();
+    }
+
+    func _approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, spender: felt, amount: Uint256
+    ) {
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);
+        }
+
+        with_attr error_message("ERC20: cannot approve from the zero address") {
+            assert_not_zero(owner);
+        }
+
+        with_attr error_message("ERC20: cannot approve to the zero address") {
+            assert_not_zero(spender);
+        }
+
+        ERC20_allowances.write(owner, spender, amount);
+        Approval.emit(owner, spender, amount);
+        return ();
+    }
+
+    func _spend_allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, spender: felt, amount: Uint256
+    ) {
+        alloc_locals;
+        with_attr error_message("ERC20: amount is not a valid Uint256") {
+            uint256_check(amount);  // almost surely not needed, might remove after confirmation
+        }
+
+        let (current_allowance: Uint256) = ERC20_allowances.read(owner, spender);
+        let (infinite: Uint256) = uint256_not(Uint256(0, 0));
+        let (is_infinite: felt) = uint256_eq(current_allowance, infinite);
+
+        if (is_infinite == FALSE) {
+            with_attr error_message("ERC20: insufficient allowance") {
+                let (new_allowance: Uint256) = SafeUint256.sub_le(current_allowance, amount);
+            }
+
+            _approve(owner, spender, new_allowance);
+            return ();
+        }
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20.cairo
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/presets/ERC20.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import ERC20
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, initial_supply: Uint256, recipient: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    ERC20._mint(recipient, initial_supply);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC20.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC20.symbol();
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    return ERC20.decimals();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    return ERC20.balance_of(account);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    return ERC20.allowance(owner, spender);
+}
+
+//
+// Externals
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer(recipient, amount);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer_from(sender, recipient, amount);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.approve(spender, amount);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    return ERC20.increase_allowance(spender, added_value);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    return ERC20.decrease_allowance(spender, subtracted_value);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Burnable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Burnable.cairo
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Cairo Contracts v0.6.1 (token/erc20/presets/ERC20Burnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.starknet.common.syscalls import get_caller_address
+
+from openzeppelin.token.erc20.library import ERC20
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, initial_supply: Uint256, recipient: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    ERC20._mint(recipient, initial_supply);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC20.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC20.symbol();
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    return ERC20.decimals();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    return ERC20.balance_of(account);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    return ERC20.allowance(owner, spender);
+}
+
+//
+// External
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer(recipient, amount);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer_from(sender, recipient, amount);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.approve(spender, amount);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    return ERC20.increase_allowance(spender, added_value);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    return ERC20.decrease_allowance(spender, subtracted_value);
+}
+
+@external
+func burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(amount: Uint256) {
+    let (caller) = get_caller_address();
+    ERC20._burn(caller, amount);
+    return ();
+}
+
+@external
+func burnFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, amount: Uint256
+) {
+    let (caller) = get_caller_address();
+    ERC20._spend_allowance(account, caller, amount);
+    ERC20._burn(account, amount);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Mintable.cairo
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/presets/ERC20Mintable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.token.erc20.library import ERC20
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, initial_supply: Uint256, recipient: felt, owner: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    ERC20._mint(recipient, initial_supply);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC20.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC20.symbol();
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    return ERC20.decimals();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    return ERC20.balance_of(account);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    return ERC20.allowance(owner, spender);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer(recipient, amount);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer_from(sender, recipient, amount);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.approve(spender, amount);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    return ERC20.increase_allowance(spender, added_value);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    return ERC20.decrease_allowance(spender, subtracted_value);
+}
+
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, amount: Uint256
+) {
+    Ownable.assert_only_owner();
+    ERC20._mint(to, amount);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Pausable.cairo
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/presets/ERC20Pausable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.security.pausable.library import Pausable
+from openzeppelin.token.erc20.library import ERC20
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, decimals: felt, initial_supply: Uint256, recipient: felt, owner: felt
+) {
+    ERC20.initializer(name, symbol, decimals);
+    ERC20._mint(recipient, initial_supply);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC20.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC20.symbol();
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    return ERC20.decimals();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    return ERC20.balance_of(account);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    return ERC20.allowance(owner, spender);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+@view
+func paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (paused: felt) {
+    return Pausable.is_paused();
+}
+
+//
+// Externals
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.transfer(recipient, amount);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.transfer_from(sender, recipient, amount);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.approve(spender, amount);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.increase_allowance(spender, added_value);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    Pausable.assert_not_paused();
+    return ERC20.decrease_allowance(spender, subtracted_value);
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}
+
+@external
+func pause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.assert_only_owner();
+    Pausable._pause();
+    return ();
+}
+
+@external
+func unpause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.assert_only_owner();
+    Pausable._unpause();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc20/presets/ERC20Upgradeable.cairo
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc20/presets/ERC20Upgradeable.cairo)
+
+%lang starknet
+%builtins pedersen range_check
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc20.library import ERC20
+from openzeppelin.upgrades.library import Proxy
+
+//
+// Initializer
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt,
+    symbol: felt,
+    decimals: felt,
+    initial_supply: Uint256,
+    recipient: felt,
+    proxy_admin: felt,
+) {
+    ERC20.initializer(name, symbol, decimals);
+    ERC20._mint(recipient, initial_supply);
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+@external
+func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    new_implementation: felt
+) {
+    Proxy.assert_only_admin();
+    Proxy._set_implementation_hash(new_implementation);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC20.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC20.symbol();
+}
+
+@view
+func totalSupply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC20.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func decimals{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    decimals: felt
+) {
+    return ERC20.decimals();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(account: felt) -> (
+    balance: Uint256
+) {
+    return ERC20.balance_of(account);
+}
+
+@view
+func allowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, spender: felt
+) -> (remaining: Uint256) {
+    return ERC20.allowance(owner, spender);
+}
+
+//
+// Externals
+//
+
+@external
+func transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer(recipient, amount);
+}
+
+@external
+func transferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    sender: felt, recipient: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.transfer_from(sender, recipient, amount);
+}
+
+@external
+func approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, amount: Uint256
+) -> (success: felt) {
+    return ERC20.approve(spender, amount);
+}
+
+@external
+func increaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, added_value: Uint256
+) -> (success: felt) {
+    return ERC20.increase_allowance(spender, added_value);
+}
+
+@external
+func decreaseAllowance{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    spender: felt, subtracted_value: Uint256
+) -> (success: felt) {
+    return ERC20.decrease_allowance(spender, subtracted_value);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721.cairo
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/IERC721.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC721 {
+    func balanceOf(owner: felt) -> (balance: Uint256) {
+    }
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt) {
+    }
+
+    func safeTransferFrom(from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*) {
+    }
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256) {
+    }
+
+    func approve(approved: felt, tokenId: Uint256) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func getApproved(tokenId: Uint256) -> (approved: felt) {
+    }
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (approved: felt) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721Metadata.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721Metadata.cairo
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/IERC721Metadata.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC721Metadata {
+    func name() -> (name: felt) {
+    }
+
+    func symbol() -> (symbol: felt) {
+    }
+
+    func tokenURI(tokenId: Uint256) -> (tokenURI: felt) {
+    }
+
+    /// IERC721
+
+    func balanceOf(owner: felt) -> (balance: Uint256) {
+    }
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt) {
+    }
+
+    func safeTransferFrom(from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*) {
+    }
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256) {
+    }
+
+    func approve(approved: felt, tokenId: Uint256) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func getApproved(tokenId: Uint256) -> (approved: felt) {
+    }
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (approved: felt) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721Receiver.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/IERC721Receiver.cairo
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/IERC721Receiver.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC721Receiver {
+    func onERC721Received(
+        operator: felt,
+        from_: felt,
+        tokenId: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (selector: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/IERC721Enumerable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/IERC721Enumerable.cairo
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/enumerable/IERC721Enumerable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC721Enumerable {
+    func totalSupply() -> (totalSupply: Uint256) {
+    }
+
+    func tokenByIndex(index: Uint256) -> (tokenId: Uint256) {
+    }
+
+    func tokenOfOwnerByIndex(owner: felt, index: Uint256) -> (tokenId: Uint256) {
+    }
+
+    /// IERC721
+
+    func balanceOf(owner: felt) -> (balance: Uint256) {
+    }
+
+    func ownerOf(tokenId: Uint256) -> (owner: felt) {
+    }
+
+    func safeTransferFrom(from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*) {
+    }
+
+    func transferFrom(from_: felt, to: felt, tokenId: Uint256) {
+    }
+
+    func approve(approved: felt, tokenId: Uint256) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func getApproved(tokenId: Uint256) -> (approved: felt) {
+    }
+
+    func isApprovedForAll(owner: felt, operator: felt) -> (approved: felt) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/library.cairo
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/enumerable/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256, uint256_lt, uint256_eq, uint256_check
+
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.token.erc721.library import ERC721
+from openzeppelin.utils.constants.library import IERC721_ENUMERABLE_ID
+
+//
+// Storage
+//
+
+@storage_var
+func ERC721Enumerable_all_tokens_len() -> (total_supply: Uint256) {
+}
+
+@storage_var
+func ERC721Enumerable_all_tokens(index: Uint256) -> (token_id: Uint256) {
+}
+
+@storage_var
+func ERC721Enumerable_all_tokens_index(token_id: Uint256) -> (index: Uint256) {
+}
+
+@storage_var
+func ERC721Enumerable_owned_tokens(owner: felt, index: Uint256) -> (token_id: Uint256) {
+}
+
+@storage_var
+func ERC721Enumerable_owned_tokens_index(token_id: Uint256) -> (index: Uint256) {
+}
+
+namespace ERC721Enumerable {
+    //
+    // Constructor
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        ERC165.register_interface(IERC721_ENUMERABLE_ID);
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func total_supply{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        total_supply: Uint256
+    ) {
+        return ERC721Enumerable_all_tokens_len.read();
+    }
+
+    func token_by_index{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        index: Uint256
+    ) -> (token_id: Uint256) {
+        alloc_locals;
+        uint256_check(index);
+        // Ensures index argument is less than total_supply
+        let (len: Uint256) = ERC721Enumerable.total_supply();
+        let (is_lt) = uint256_lt(index, len);
+        with_attr error_message("ERC721Enumerable: global index out of bounds") {
+            assert is_lt = TRUE;
+        }
+
+        return ERC721Enumerable_all_tokens.read(index);
+    }
+
+    func token_of_owner_by_index{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, index: Uint256
+    ) -> (token_id: Uint256) {
+        alloc_locals;
+        uint256_check(index);
+        // Ensures index argument is less than owner's balance
+        let (len: Uint256) = ERC721.balance_of(owner);
+        let (is_lt) = uint256_lt(index, len);
+        with_attr error_message("ERC721Enumerable: owner index out of bounds") {
+            assert is_lt = TRUE;
+        }
+
+        return ERC721Enumerable_owned_tokens.read(owner, index);
+    }
+
+    //
+    // Externals
+    //
+    func transfer_from{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256
+    ) {
+        _remove_token_from_owner_enumeration(from_, token_id);
+        _add_token_to_owner_enumeration(to, token_id);
+        ERC721.transfer_from(from_, to, token_id);
+        return ();
+    }
+
+    func safe_transfer_from{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256, data_len: felt, data: felt*
+    ) {
+        _remove_token_from_owner_enumeration(from_, token_id);
+        _add_token_to_owner_enumeration(to, token_id);
+        ERC721.safe_transfer_from(from_, to, token_id, data_len, data);
+        return ();
+    }
+
+    //
+    // Internals
+    //
+
+    func _mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        to: felt, token_id: Uint256
+    ) {
+        _add_token_to_all_tokens_enumeration(token_id);
+        _add_token_to_owner_enumeration(to, token_id);
+        ERC721._mint(to, token_id);
+        return ();
+    }
+
+    func _burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(token_id: Uint256) {
+        let (from_) = ERC721.owner_of(token_id);
+        _remove_token_from_owner_enumeration(from_, token_id);
+        _remove_token_from_all_tokens_enumeration(token_id);
+        ERC721._burn(token_id);
+        return ();
+    }
+}
+
+//
+// Private
+//
+
+func _add_token_to_all_tokens_enumeration{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr
+}(token_id: Uint256) {
+    let (supply: Uint256) = ERC721Enumerable_all_tokens_len.read();
+    ERC721Enumerable_all_tokens.write(supply, token_id);
+    ERC721Enumerable_all_tokens_index.write(token_id, supply);
+
+    let (new_supply: Uint256) = SafeUint256.add(supply, Uint256(1, 0));
+    ERC721Enumerable_all_tokens_len.write(new_supply);
+    return ();
+}
+
+func _remove_token_from_all_tokens_enumeration{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr
+}(token_id: Uint256) {
+    alloc_locals;
+    let (supply: Uint256) = ERC721Enumerable_all_tokens_len.read();
+    let (last_token_index: Uint256) = SafeUint256.sub_le(supply, Uint256(1, 0));
+    let (token_index: Uint256) = ERC721Enumerable_all_tokens_index.read(token_id);
+    let (last_token_id: Uint256) = ERC721Enumerable_all_tokens.read(last_token_index);
+
+    ERC721Enumerable_all_tokens.write(last_token_index, Uint256(0, 0));
+    ERC721Enumerable_all_tokens_index.write(token_id, Uint256(0, 0));
+    ERC721Enumerable_all_tokens_len.write(last_token_index);
+
+    let (is_equal) = uint256_eq(last_token_index, token_index);
+    if (is_equal == FALSE) {
+        ERC721Enumerable_all_tokens_index.write(last_token_id, token_index);
+        ERC721Enumerable_all_tokens.write(token_index, last_token_id);
+        return ();
+    }
+    return ();
+}
+
+func _add_token_to_owner_enumeration{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr
+}(to: felt, token_id: Uint256) {
+    let (length: Uint256) = ERC721.balance_of(to);
+    ERC721Enumerable_owned_tokens.write(to, length, token_id);
+    ERC721Enumerable_owned_tokens_index.write(token_id, length);
+    return ();
+}
+
+func _remove_token_from_owner_enumeration{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr
+}(from_: felt, token_id: Uint256) {
+    alloc_locals;
+    let (last_token_index: Uint256) = ERC721.balance_of(from_);
+    // the index starts at zero therefore the user's last token index is their balance minus one
+    let (last_token_index) = SafeUint256.sub_le(last_token_index, Uint256(1, 0));
+    let (token_index: Uint256) = ERC721Enumerable_owned_tokens_index.read(token_id);
+
+    // If index is last, we can just set the return values to zero
+    let (is_equal) = uint256_eq(token_index, last_token_index);
+    if (is_equal == TRUE) {
+        ERC721Enumerable_owned_tokens_index.write(token_id, Uint256(0, 0));
+        ERC721Enumerable_owned_tokens.write(from_, last_token_index, Uint256(0, 0));
+        return ();
+    }
+
+    // If index is not last, reposition owner's last token to the removed token's index
+    let (last_token_id: Uint256) = ERC721Enumerable_owned_tokens.read(from_, last_token_index);
+    ERC721Enumerable_owned_tokens.write(from_, token_index, last_token_id);
+    ERC721Enumerable_owned_tokens_index.write(last_token_id, token_index);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/presets/ERC721EnumerableMintableBurnable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/enumerable/presets/ERC721EnumerableMintableBurnable.cairo
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/enumerable/presets/ERC721EnumerableMintableBurnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.token.erc721.library import ERC721
+from openzeppelin.token.erc721.enumerable.library import ERC721Enumerable
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, owner: felt
+) {
+    ERC721.initializer(name, symbol);
+    ERC721Enumerable.initializer();
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func totalSupply{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}() -> (
+    totalSupply: Uint256
+) {
+    let (totalSupply: Uint256) = ERC721Enumerable.total_supply();
+    return (totalSupply=totalSupply);
+}
+
+@view
+func tokenByIndex{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    index: Uint256
+) -> (tokenId: Uint256) {
+    let (tokenId: Uint256) = ERC721Enumerable.token_by_index(index);
+    return (tokenId=tokenId);
+}
+
+@view
+func tokenOfOwnerByIndex{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    owner: felt, index: Uint256
+) -> (tokenId: Uint256) {
+    let (tokenId: Uint256) = ERC721Enumerable.token_of_owner_by_index(owner, index);
+    return (tokenId=tokenId);
+}
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC721.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC721.symbol();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) -> (
+    balance: Uint256
+) {
+    return ERC721.balance_of(owner);
+}
+
+@view
+func ownerOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(tokenId: Uint256) -> (
+    owner: felt
+) {
+    return ERC721.owner_of(tokenId);
+}
+
+@view
+func getApproved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (approved: felt) {
+    return ERC721.get_approved(tokenId);
+}
+
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, operator: felt
+) -> (approved: felt) {
+    return ERC721.is_approved_for_all(owner, operator);
+}
+
+@view
+func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (tokenURI: felt) {
+    let (tokenURI: felt) = ERC721.token_uri(tokenId);
+    return (tokenURI=tokenURI);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+@external
+func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    ERC721.approve(to, tokenId);
+    return ();
+}
+
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    ERC721.set_approval_for_all(operator, approved);
+    return ();
+}
+
+@external
+func transferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256
+) {
+    ERC721Enumerable.transfer_from(from_, to, tokenId);
+    return ();
+}
+
+@external
+func safeTransferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*
+) {
+    ERC721Enumerable.safe_transfer_from(from_, to, tokenId, data_len, data);
+    return ();
+}
+
+@external
+func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    Ownable.assert_only_owner();
+    ERC721Enumerable._mint(to, tokenId);
+    return ();
+}
+
+@external
+func burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(tokenId: Uint256) {
+    ERC721.assert_only_token_owner(tokenId);
+    ERC721Enumerable._burn(tokenId);
+    return ();
+}
+
+@external
+func setTokenURI{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    tokenId: Uint256, tokenURI: felt
+) {
+    Ownable.assert_only_owner();
+    ERC721._set_token_uri(tokenId, tokenURI);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/library.cairo
@@ -1,0 +1,471 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.math import assert_not_zero, assert_not_equal
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import Uint256, uint256_check
+
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.introspection.erc165.IERC165 import IERC165
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.token.erc721.IERC721Receiver import IERC721Receiver
+from openzeppelin.utils.constants.library import (
+    IERC721_ID,
+    IERC721_METADATA_ID,
+    IERC721_RECEIVER_ID,
+    IACCOUNT_ID,
+)
+
+//
+// Events
+//
+
+@event
+func Transfer(from_: felt, to: felt, tokenId: Uint256) {
+}
+
+@event
+func Approval(owner: felt, approved: felt, tokenId: Uint256) {
+}
+
+@event
+func ApprovalForAll(owner: felt, operator: felt, approved: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func ERC721_name() -> (name: felt) {
+}
+
+@storage_var
+func ERC721_symbol() -> (symbol: felt) {
+}
+
+@storage_var
+func ERC721_owners(token_id: Uint256) -> (owner: felt) {
+}
+
+@storage_var
+func ERC721_balances(account: felt) -> (balance: Uint256) {
+}
+
+@storage_var
+func ERC721_token_approvals(token_id: Uint256) -> (approved: felt) {
+}
+
+@storage_var
+func ERC721_operator_approvals(owner: felt, operator: felt) -> (approved: felt) {
+}
+
+@storage_var
+func ERC721_token_uri(token_id: Uint256) -> (token_uri: felt) {
+}
+
+namespace ERC721 {
+    //
+    // Constructor
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        name: felt, symbol: felt
+    ) {
+        ERC721_name.write(name);
+        ERC721_symbol.write(symbol);
+        ERC165.register_interface(IERC721_ID);
+        ERC165.register_interface(IERC721_METADATA_ID);
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+        return ERC721_name.read();
+    }
+
+    func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        symbol: felt
+    ) {
+        return ERC721_symbol.read();
+    }
+
+    func balance_of{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt
+    ) -> (balance: Uint256) {
+        with_attr error_message("ERC721: balance query for the zero address") {
+            assert_not_zero(owner);
+        }
+        return ERC721_balances.read(owner);
+    }
+
+    func owner_of{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        token_id: Uint256
+    ) -> (owner: felt) {
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        let (owner) = ERC721_owners.read(token_id);
+        with_attr error_message("ERC721: owner query for nonexistent token") {
+            assert_not_zero(owner);
+        }
+        return (owner=owner);
+    }
+
+    func get_approved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        token_id: Uint256
+    ) -> (approved: felt) {
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        let exists = _exists(token_id);
+        with_attr error_message("ERC721: approved query for nonexistent token") {
+            assert exists = TRUE;
+        }
+
+        return ERC721_token_approvals.read(token_id);
+    }
+
+    func is_approved_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, operator: felt
+    ) -> (approved: felt) {
+        return ERC721_operator_approvals.read(owner, operator);
+    }
+
+    func token_uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        token_id: Uint256
+    ) -> (token_uri: felt) {
+        let exists = _exists(token_id);
+        with_attr error_message("ERC721_Metadata: URI query for nonexistent token") {
+            assert exists = TRUE;
+        }
+
+        // if tokenURI is not set, it will return 0
+        return ERC721_token_uri.read(token_id);
+    }
+
+    //
+    // Externals
+    //
+
+    func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        to: felt, token_id: Uint256
+    ) {
+        with_attr error_mesage("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+
+        // Checks caller is not zero address
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC721: cannot approve from the zero address") {
+            assert_not_zero(caller);
+        }
+
+        // Ensures 'owner' does not equal 'to'
+        let (owner) = ERC721_owners.read(token_id);
+        with_attr error_message("ERC721: approval to current owner") {
+            assert_not_equal(owner, to);
+        }
+
+        // Checks that either caller equals owner or
+        // caller isApprovedForAll on behalf of owner
+        if (caller == owner) {
+            _approve(to, token_id);
+            return ();
+        } else {
+            let (is_approved) = ERC721_operator_approvals.read(owner, caller);
+            with_attr error_message("ERC721: approve caller is not owner nor approved for all") {
+                assert_not_zero(is_approved);
+            }
+            _approve(to, token_id);
+            return ();
+        }
+    }
+
+    func set_approval_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        operator: felt, approved: felt
+    ) {
+        // Ensures caller is neither zero address nor operator
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC721: either the caller or operator is the zero address") {
+            assert_not_zero(caller * operator);
+        }
+        // note this pattern as we'll frequently use it:
+        //   instead of making an `assert_not_zero` call for each address
+        //   we can always briefly write `assert_not_zero(a0 * a1 * ... * aN)`.
+        //   This is because these addresses are field elements,
+        //   meaning that a*0==0 for all a in the field,
+        //   and a*b==0 implies that at least one of a,b are zero in the field
+        with_attr error_message("ERC721: approve to caller") {
+            assert_not_equal(caller, operator);
+        }
+
+        // Make sure `approved` is a boolean (0 or 1)
+        with_attr error_message("ERC721: approved is not a Cairo boolean") {
+            assert approved * (1 - approved) = 0;
+        }
+
+        ERC721_operator_approvals.write(owner=caller, operator=operator, value=approved);
+        ApprovalForAll.emit(caller, operator, approved);
+        return ();
+    }
+
+    func transfer_from{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256
+    ) {
+        alloc_locals;
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        let (caller) = get_caller_address();
+        let is_approved = _is_approved_or_owner(caller, token_id);
+        with_attr error_message(
+                "ERC721: either is not approved or the caller is the zero address") {
+            assert_not_zero(caller * is_approved);
+        }
+        // Note that if either `is_approved` or `caller` equals `0`,
+        // then this method should fail.
+        // The `caller` address and `is_approved` boolean are both field elements
+        // meaning that a*0==0 for all a in the field,
+        // therefore a*b==0 implies that at least one of a,b is zero in the field
+
+        _transfer(from_, to, token_id);
+        return ();
+    }
+
+    func safe_transfer_from{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256, data_len: felt, data: felt*
+    ) {
+        alloc_locals;
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        let (caller) = get_caller_address();
+        let is_approved = _is_approved_or_owner(caller, token_id);
+        with_attr error_message(
+                "ERC721: either is not approved or the caller is the zero address") {
+            assert_not_zero(caller * is_approved);
+        }
+        // Note that if either `is_approved` or `caller` equals `0`,
+        // then this method should fail.
+        // The `caller` address and `is_approved` boolean are both field elements
+        // meaning that a*0==0 for all a in the field,
+        // therefore a*b==0 implies that at least one of a,b is zero in the field
+
+        _safe_transfer(from_, to, token_id, data_len, data);
+        return ();
+    }
+
+    //
+    // Internals
+    //
+
+    func assert_only_token_owner{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        token_id: Uint256
+    ) {
+        uint256_check(token_id);
+        let (caller) = get_caller_address();
+        let (owner) = owner_of(token_id);
+        // Note `owner_of` checks that the owner is not the zero address
+        with_attr error_message("ERC721: caller is not the token owner") {
+            assert caller = owner;
+        }
+        return ();
+    }
+
+    func _is_approved_or_owner{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        spender: felt, token_id: Uint256
+    ) -> felt {
+        alloc_locals;
+
+        let exists = _exists(token_id);
+        with_attr error_message("ERC721: token id does not exist") {
+            assert exists = TRUE;
+        }
+
+        let (owner) = owner_of(token_id);
+        if (owner == spender) {
+            return TRUE;
+        }
+
+        let (approved_addr) = get_approved(token_id);
+        if (approved_addr == spender) {
+            return TRUE;
+        }
+
+        let (is_operator) = is_approved_for_all(owner, spender);
+        if (is_operator == TRUE) {
+            return TRUE;
+        }
+
+        return FALSE;
+    }
+
+    func _exists{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        token_id: Uint256
+    ) -> felt {
+        let (exists) = ERC721_owners.read(token_id);
+        if (exists == FALSE) {
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
+    func _approve{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        to: felt, token_id: Uint256
+    ) {
+        ERC721_token_approvals.write(token_id, to);
+        let (owner) = owner_of(token_id);
+        Approval.emit(owner, to, token_id);
+        return ();
+    }
+
+    func _transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256
+    ) {
+        // ownerOf ensures 'from_' is not the zero address
+        let (owner) = owner_of(token_id);
+        with_attr error_message("ERC721: transfer from incorrect owner") {
+            assert owner = from_;
+        }
+
+        with_attr error_message("ERC721: cannot transfer to the zero address") {
+            assert_not_zero(to);
+        }
+
+        // Clear approvals
+        _approve(0, token_id);
+
+        // Decrease owner balance
+        let (owner_bal) = ERC721_balances.read(from_);
+        let (new_balance: Uint256) = SafeUint256.sub_le(owner_bal, Uint256(1, 0));
+        ERC721_balances.write(from_, new_balance);
+
+        // Increase receiver balance
+        let (receiver_bal) = ERC721_balances.read(to);
+        let (new_balance: Uint256) = SafeUint256.add(receiver_bal, Uint256(1, 0));
+        ERC721_balances.write(to, new_balance);
+
+        // Update token_id owner
+        ERC721_owners.write(token_id, to);
+        Transfer.emit(from_, to, token_id);
+        return ();
+    }
+
+    func _safe_transfer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, token_id: Uint256, data_len: felt, data: felt*
+    ) {
+        _transfer(from_, to, token_id);
+
+        let (success) = _check_onERC721Received(from_, to, token_id, data_len, data);
+        with_attr error_message("ERC721: transfer to non ERC721Receiver implementer") {
+            assert_not_zero(success);
+        }
+        return ();
+    }
+
+    func _mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        to: felt, token_id: Uint256
+    ) {
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        with_attr error_message("ERC721: cannot mint to the zero address") {
+            assert_not_zero(to);
+        }
+
+        // Ensures token_id is unique
+        let exists = _exists(token_id);
+        with_attr error_message("ERC721: token already minted") {
+            assert exists = FALSE;
+        }
+
+        let (balance: Uint256) = ERC721_balances.read(to);
+        let (new_balance: Uint256) = SafeUint256.add(balance, Uint256(1, 0));
+        ERC721_balances.write(to, new_balance);
+        ERC721_owners.write(token_id, to);
+        Transfer.emit(0, to, token_id);
+        return ();
+    }
+
+    func _safe_mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+        to: felt, token_id: Uint256, data_len: felt, data: felt*
+    ) {
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        _mint(to, token_id);
+
+        let (success) = _check_onERC721Received(0, to, token_id, data_len, data);
+        with_attr error_message("ERC721: transfer to non ERC721Receiver implementer") {
+            assert_not_zero(success);
+        }
+        return ();
+    }
+
+    func _burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(token_id: Uint256) {
+        alloc_locals;
+        with_attr error_message("ERC721: token_id is not a valid Uint256") {
+            uint256_check(token_id);
+        }
+        let (owner) = owner_of(token_id);
+
+        // Clear approvals
+        _approve(0, token_id);
+
+        // Decrease owner balance
+        let (balance: Uint256) = ERC721_balances.read(owner);
+        let (new_balance: Uint256) = SafeUint256.sub_le(balance, Uint256(1, 0));
+        ERC721_balances.write(owner, new_balance);
+
+        // Delete owner
+        ERC721_owners.write(token_id, 0);
+        Transfer.emit(owner, 0, token_id);
+        return ();
+    }
+
+    func _set_token_uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        token_id: Uint256, token_uri: felt
+    ) {
+        uint256_check(token_id);
+        let exists = _exists(token_id);
+        with_attr error_message("ERC721_Metadata: set token URI for nonexistent token") {
+            assert exists = TRUE;
+        }
+
+        ERC721_token_uri.write(token_id, token_uri);
+        return ();
+    }
+}
+
+//
+// Private
+//
+
+func _check_onERC721Received{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, to: felt, token_id: Uint256, data_len: felt, data: felt*
+) -> (success: felt) {
+    let (caller) = get_caller_address();
+    let (is_supported) = IERC165.supportsInterface(to, IERC721_RECEIVER_ID);
+    if (is_supported == TRUE) {
+        let (selector) = IERC721Receiver.onERC721Received(
+            to, caller, from_, token_id, data_len, data
+        );
+
+        with_attr error_message("ERC721: transfer to non ERC721Receiver implementer") {
+            assert selector = IERC721_RECEIVER_ID;
+        }
+        return (success=TRUE);
+    }
+
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID);
+    return (success=is_account);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/ERC721MintableBurnable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/ERC721MintableBurnable.cairo
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/presets/ERC721MintableBurnable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.token.erc721.library import ERC721
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, owner: felt
+) {
+    ERC721.initializer(name, symbol);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC721.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC721.symbol();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) -> (
+    balance: Uint256
+) {
+    return ERC721.balance_of(owner);
+}
+
+@view
+func ownerOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(tokenId: Uint256) -> (
+    owner: felt
+) {
+    return ERC721.owner_of(tokenId);
+}
+
+@view
+func getApproved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (approved: felt) {
+    return ERC721.get_approved(tokenId);
+}
+
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, operator: felt
+) -> (approved: felt) {
+    return ERC721.is_approved_for_all(owner, operator);
+}
+
+@view
+func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (tokenURI: felt) {
+    let (tokenURI: felt) = ERC721.token_uri(tokenId);
+    return (tokenURI=tokenURI);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+@external
+func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    ERC721.approve(to, tokenId);
+    return ();
+}
+
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    ERC721.set_approval_for_all(operator, approved);
+    return ();
+}
+
+@external
+func transferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256
+) {
+    ERC721.transfer_from(from_, to, tokenId);
+    return ();
+}
+
+@external
+func safeTransferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*
+) {
+    ERC721.safe_transfer_from(from_, to, tokenId, data_len, data);
+    return ();
+}
+
+@external
+func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    Ownable.assert_only_owner();
+    ERC721._mint(to, tokenId);
+    return ();
+}
+
+@external
+func burn{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(tokenId: Uint256) {
+    ERC721.assert_only_token_owner(tokenId);
+    ERC721._burn(tokenId);
+    return ();
+}
+
+@external
+func setTokenURI{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    tokenId: Uint256, tokenURI: felt
+) {
+    Ownable.assert_only_owner();
+    ERC721._set_token_uri(tokenId, tokenURI);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/ERC721MintablePausable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/ERC721MintablePausable.cairo
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/presets/ERC721MintablePausable.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.security.pausable.library import Pausable
+from openzeppelin.token.erc721.library import ERC721
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, owner: felt
+) {
+    ERC721.initializer(name, symbol);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC721.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC721.symbol();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) -> (
+    balance: Uint256
+) {
+    return ERC721.balance_of(owner);
+}
+
+@view
+func ownerOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(tokenId: Uint256) -> (
+    owner: felt
+) {
+    return ERC721.owner_of(tokenId);
+}
+
+@view
+func getApproved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (approved: felt) {
+    return ERC721.get_approved(tokenId);
+}
+
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, operator: felt
+) -> (approved: felt) {
+    return ERC721.is_approved_for_all(owner, operator);
+}
+
+@view
+func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (tokenURI: felt) {
+    let (tokenURI: felt) = ERC721.token_uri(tokenId);
+    return (tokenURI=tokenURI);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+@view
+func paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (paused: felt) {
+    return Pausable.is_paused();
+}
+
+//
+// Externals
+//
+
+@external
+func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    Pausable.assert_not_paused();
+    ERC721.approve(to, tokenId);
+    return ();
+}
+
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    Pausable.assert_not_paused();
+    ERC721.set_approval_for_all(operator, approved);
+    return ();
+}
+
+@external
+func transferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256
+) {
+    Pausable.assert_not_paused();
+    ERC721.transfer_from(from_, to, tokenId);
+    return ();
+}
+
+@external
+func safeTransferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*
+) {
+    Pausable.assert_not_paused();
+    ERC721.safe_transfer_from(from_, to, tokenId, data_len, data);
+    return ();
+}
+
+@external
+func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    Pausable.assert_not_paused();
+    Ownable.assert_only_owner();
+    ERC721._mint(to, tokenId);
+    return ();
+}
+
+@external
+func setTokenURI{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    tokenId: Uint256, tokenURI: felt
+) {
+    Ownable.assert_only_owner();
+    ERC721._set_token_uri(tokenId, tokenURI);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}
+
+@external
+func pause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.assert_only_owner();
+    Pausable._pause();
+    return ();
+}
+
+@external
+func unpause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.assert_only_owner();
+    Pausable._unpause();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/utils/ERC721Holder.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/token/erc721/presets/utils/ERC721Holder.cairo
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc721/presets/utils/ERC721Holder.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.utils.constants.library import IERC721_RECEIVER_ID
+
+from openzeppelin.introspection.erc165.library import ERC165
+
+@view
+func onERC721Received(
+    operator: felt, from_: felt, tokenId: Uint256, data_len: felt, data: felt*
+) -> (selector: felt) {
+    return (selector=IERC721_RECEIVER_ID);
+}
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    ERC165.register_interface(IERC721_RECEIVER_ID);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/upgrades/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/upgrades/library.cairo
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (upgrades/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.math import assert_not_zero
+
+//
+// Events
+//
+
+@event
+func Upgraded(implementation: felt) {
+}
+
+@event
+func AdminChanged(previousAdmin: felt, newAdmin: felt) {
+}
+
+//
+// Storage variables
+//
+
+@storage_var
+func Proxy_implementation_hash() -> (implementation: felt) {
+}
+
+@storage_var
+func Proxy_admin() -> (admin: felt) {
+}
+
+@storage_var
+func Proxy_initialized() -> (initialized: felt) {
+}
+
+namespace Proxy {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        proxy_admin: felt
+    ) {
+        let (initialized) = Proxy_initialized.read();
+        with_attr error_message("Proxy: contract already initialized") {
+            assert initialized = FALSE;
+        }
+
+        Proxy_initialized.write(TRUE);
+        _set_admin(proxy_admin);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (caller) = get_caller_address();
+        let (admin) = Proxy_admin.read();
+        with_attr error_message("Proxy: caller is not admin") {
+            assert admin = caller;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func get_implementation_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        ) -> (implementation: felt) {
+        return Proxy_implementation_hash.read();
+    }
+
+    func get_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        admin: felt
+    ) {
+        return Proxy_admin.read();
+    }
+
+    //
+    // Unprotected
+    //
+
+    func _set_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_admin: felt
+    ) {
+        let (previous_admin) = get_admin();
+        Proxy_admin.write(new_admin);
+        AdminChanged.emit(previous_admin, new_admin);
+        return ();
+    }
+
+    //
+    // Upgrade
+    //
+
+    func _set_implementation_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_implementation: felt
+    ) {
+        with_attr error_message("Proxy: implementation hash cannot be zero") {
+            assert_not_zero(new_implementation);
+        }
+
+        Proxy_implementation_hash.write(new_implementation);
+        Upgraded.emit(new_implementation);
+        return ();
+    }
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/upgrades/presets/Proxy.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/upgrades/presets/Proxy.cairo
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (upgrades/presets/Proxy.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import library_call, library_call_l1_handler
+
+from openzeppelin.upgrades.library import Proxy
+
+// @dev Cairo doesn't support native decoding like Solidity yet,
+//      that's why we pass three arguments for calldata instead of one
+// @param implementation_hash the implementation contract hash
+// @param selector the implementation initializer function selector
+// @param calldata_len the calldata length for the initializer
+// @param calldata an array of felt containing the raw calldata
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    implementation_hash: felt, selector: felt,
+    calldata_len: felt, calldata: felt*
+) {
+    alloc_locals;
+    Proxy._set_implementation_hash(implementation_hash);
+
+    if (selector != 0) {
+        // Initialize proxy from implementation
+        library_call(
+            class_hash=implementation_hash,
+            function_selector=selector,
+            calldata_size=calldata_len,
+            calldata=calldata,
+        );
+    }
+
+    return ();
+}
+
+//
+// Fallback functions
+//
+
+@external
+@raw_input
+@raw_output
+func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) -> (retdata_size: felt, retdata: felt*) {
+    let (class_hash) = Proxy.get_implementation_hash();
+
+    let (retdata_size: felt, retdata: felt*) = library_call(
+        class_hash=class_hash,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata,
+    );
+    return (retdata_size, retdata);
+}
+
+@l1_handler
+@raw_input
+func __l1_default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) {
+    let (class_hash) = Proxy.get_implementation_hash();
+
+    library_call_l1_handler(
+        class_hash=class_hash,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata,
+    );
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/utils/constants/library.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/utils/constants/library.cairo
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (utils/constants/library.cairo)
+
+%lang starknet
+
+//
+// Numbers
+//
+
+const UINT8_MAX = 255;
+
+//
+// Interface Ids
+//
+
+// ERC165
+const IERC165_ID = 0x01ffc9a7;
+const INVALID_ID = 0xffffffff;
+
+// Account
+const IACCOUNT_ID = 0xa66bd575;
+
+// ERC721
+const IERC721_ID = 0x80ac58cd;
+const IERC721_RECEIVER_ID = 0x150b7a02;
+const IERC721_METADATA_ID = 0x5b5e139f;
+const IERC721_ENUMERABLE_ID = 0x780e9d63;
+
+// ERC1155
+const IERC1155_ID = 0xd9b67a26;
+const IERC1155_METADATA_ID = 0x0e89341c;
+const IERC1155_RECEIVER_ID = 0x4e2312e0;
+const ON_ERC1155_RECEIVED_SELECTOR = 0xf23a6e61;
+const ON_ERC1155_BATCH_RECEIVED_SELECTOR = 0xbc197c81;
+
+// AccessControl
+const IACCESSCONTROL_ID = 0x7965db0b;
+
+//
+// Roles
+//
+
+const DEFAULT_ADMIN_ROLE = 0;
+
+//
+// Starknet
+//
+
+const TRANSACTION_VERSION = 1;

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/utils/presets/UniversalDeployer.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/src/openzeppelin/utils/presets/UniversalDeployer.cairo
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (utils/presets/UniversalDeployer.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address, deploy
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.hash import hash2
+from starkware.cairo.common.bool import FALSE, TRUE
+
+@event
+func ContractDeployed(
+    address: felt,
+    deployer: felt,
+    unique: felt,
+    classHash: felt,
+    calldata_len: felt,
+    calldata: felt*,
+    salt: felt
+) {
+}
+
+@external
+func deployContract{
+    syscall_ptr: felt*,
+    pedersen_ptr: HashBuiltin*,
+    range_check_ptr
+}(
+    classHash: felt,
+    salt: felt,
+    unique: felt,
+    calldata_len: felt,
+    calldata: felt*
+) -> (address: felt) {
+    alloc_locals;
+    let (deployer) = get_caller_address();
+
+    local _salt;
+    local from_zero;
+    if (unique == TRUE) {
+        let (unique_salt) = hash2{hash_ptr=pedersen_ptr}(deployer, salt);
+        _salt = unique_salt;
+        from_zero = FALSE;
+        tempvar _pedersen = pedersen_ptr;
+    } else {
+        _salt = salt;
+        from_zero = TRUE;
+        tempvar _pedersen = pedersen_ptr;
+    }
+
+    let pedersen_ptr = _pedersen;
+
+    let (address) = deploy(
+        class_hash=classHash,
+        contract_address_salt=_salt,
+        constructor_calldata_size=calldata_len,
+        constructor_calldata=calldata,
+        deploy_from_zero=from_zero,
+    );
+
+    ContractDeployed.emit(
+        address=address,
+        deployer=deployer,
+        unique=unique,
+        classHash=classHash,
+        calldata_len=calldata_len,
+        calldata=calldata,
+        salt=salt
+    );
+
+    return (address=address);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/OwnableBaseSuite.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/OwnableBaseSuite.py
@@ -1,0 +1,65 @@
+import pytest
+from signers import MockSigner
+from nile.utils import ZERO_ADDRESS
+from utils import assert_event_emitted
+
+
+signer = MockSigner(123456789987654321)
+
+
+class OwnableBase:
+    @pytest.mark.asyncio
+    async def test_constructor(self, contract_factory):
+        ownable, owner, *_ = contract_factory
+        expected = await ownable.owner().call()
+        assert expected.result.owner == owner.contract_address
+
+
+    @pytest.mark.asyncio
+    async def test_transferOwnership(self, contract_factory):
+        ownable, owner, *_ = contract_factory
+        new_owner = 123
+        await signer.send_transaction(owner, ownable.contract_address, 'transferOwnership', [new_owner])
+        executed_info = await ownable.owner().call()
+        assert executed_info.result == (new_owner,)
+
+
+    @pytest.mark.asyncio
+    async def test_transferOwnership_emits_event(self, contract_factory):
+        ownable, owner, *_ = contract_factory
+        new_owner = 123
+        tx_exec_info = await signer.send_transaction(owner, ownable.contract_address, 'transferOwnership', [new_owner])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=ownable.contract_address,
+            name='OwnershipTransferred',
+            data=[
+                owner.contract_address,
+                new_owner
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_renounceOwnership(self, contract_factory):
+        ownable, owner, *_ = contract_factory
+        await signer.send_transaction(owner, ownable.contract_address, 'renounceOwnership', [])
+        executed_info = await ownable.owner().call()
+        assert executed_info.result == (ZERO_ADDRESS,)
+
+
+    @pytest.mark.asyncio
+    async def test_renounceOwnership_emits_event(self, contract_factory):
+        ownable, owner, *_ = contract_factory
+        tx_exec_info = await signer.send_transaction(owner, ownable.contract_address, 'renounceOwnership', [])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=ownable.contract_address,
+            name='OwnershipTransferred',
+            data=[
+                owner.contract_address,
+                ZERO_ADDRESS
+            ]
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/test_AccessControl.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/test_AccessControl.py
@@ -1,0 +1,231 @@
+import pytest
+from pathlib import Path
+from signers import MockSigner
+from nile.utils import TRUE, FALSE, assert_revert
+from utils import (
+    State, Account, assert_event_emitted, get_contract_class, cached_contract
+)
+
+DEFAULT_ADMIN_ROLE = 0
+SOME_OTHER_ROLE = 42
+IACCESSCONTROL_ID = 0x7965db0b
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    return {
+        Path(key).stem: get_contract_class(key)
+        for key in [
+            'Account',
+            'AccessControl',
+        ]
+    }
+
+
+@pytest.fixture(scope='module')
+async def accesscontrol_init(contract_classes):
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    accesscontrol = await starknet.deploy(
+        contract_class=contract_classes['AccessControl'],
+        constructor_calldata=[account1.contract_address]
+    )
+    return starknet.state, accesscontrol, account1, account2
+
+
+@pytest.fixture
+def accesscontrol_factory(contract_classes, accesscontrol_init):
+    state, accesscontrol, account1, account2 = accesscontrol_init
+    _state = state.copy()
+    accesscontrol = cached_contract(
+        _state, contract_classes['AccessControl'], accesscontrol)
+    account1 = cached_contract(_state, Account.get_class, account1)
+    account2 = cached_contract(_state, Account.get_class, account2)
+    return accesscontrol, account1, account2
+
+
+@pytest.mark.asyncio
+async def test_initializer(accesscontrol_factory):
+    accesscontrol, _, _ = accesscontrol_factory
+
+    execution_info = await accesscontrol.supportsInterface(IACCESSCONTROL_ID).execute()
+    assert execution_info.result == (TRUE,)
+
+
+@ pytest.mark.asyncio
+async def test_grant_role(accesscontrol_factory):
+    accesscontrol, account1, account2 = accesscontrol_factory
+
+    tx_exec_info = await signer.send_transaction(
+        account1,
+        accesscontrol.contract_address,
+        'grantRole',
+        [
+            DEFAULT_ADMIN_ROLE,
+            account2.contract_address
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=accesscontrol.contract_address,
+        name='RoleGranted',
+        data=[
+            DEFAULT_ADMIN_ROLE,         # role
+            account2.contract_address,  # account
+            account1.contract_address   # sender
+        ]
+    )
+
+    expected = await accesscontrol.hasRole(DEFAULT_ADMIN_ROLE, account2.contract_address).execute()
+    assert expected.result.hasRole == TRUE
+
+
+@ pytest.mark.asyncio
+async def test_grant_role_unauthorized(accesscontrol_factory):
+    accesscontrol, _, account2 = accesscontrol_factory
+
+    await assert_revert(
+        signer.send_transaction(account2, accesscontrol.contract_address, 'grantRole', [
+                                DEFAULT_ADMIN_ROLE, account2.contract_address]),
+        reverted_with="AccessControl: caller is missing role {}".format(
+            DEFAULT_ADMIN_ROLE)
+    )
+
+
+@ pytest.mark.asyncio
+async def test_revoke_role(accesscontrol_factory):
+    accesscontrol, account1, account2 = accesscontrol_factory
+
+    await signer.send_transaction(account1, accesscontrol.contract_address, 'grantRole', [DEFAULT_ADMIN_ROLE, account2.contract_address])
+
+    tx_exec_info = await signer.send_transaction(account2, accesscontrol.contract_address, 'revokeRole', [DEFAULT_ADMIN_ROLE, account1.contract_address])
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=accesscontrol.contract_address,
+        name='RoleRevoked',
+        data=[
+            DEFAULT_ADMIN_ROLE,         # role
+            account1.contract_address,  # account
+            account2.contract_address   # sender
+        ]
+    )
+    expected = await accesscontrol.hasRole(DEFAULT_ADMIN_ROLE, account1.contract_address).execute()
+    assert expected.result.hasRole == FALSE
+
+
+@ pytest.mark.asyncio
+async def test_revoke_role_unauthorized(accesscontrol_factory):
+    accesscontrol, account1, account2 = accesscontrol_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            account2,
+            accesscontrol.contract_address,
+            'revokeRole',
+            [
+                DEFAULT_ADMIN_ROLE,
+                account1.contract_address
+            ]
+        ),
+        reverted_with="AccessControl: caller is missing role {}".format(
+            DEFAULT_ADMIN_ROLE
+        )
+    )
+
+
+@ pytest.mark.asyncio
+async def test_renounce_role(accesscontrol_factory):
+    accesscontrol, account1, _ = accesscontrol_factory
+
+    tx_exec_info = await signer.send_transaction(
+        account1,
+        accesscontrol.contract_address,
+        'renounceRole',
+        [
+            DEFAULT_ADMIN_ROLE,
+            account1.contract_address
+        ]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=accesscontrol.contract_address,
+        name='RoleRevoked',
+        data=[
+            DEFAULT_ADMIN_ROLE,         # role
+            account1.contract_address,  # account
+            account1.contract_address   # sender
+        ]
+    )
+
+    expected = await accesscontrol.hasRole(DEFAULT_ADMIN_ROLE, account1.contract_address).execute()
+    assert expected.result.hasRole == FALSE
+
+
+@ pytest.mark.asyncio
+async def test_renounce_role_unauthorized(accesscontrol_factory):
+    accesscontrol, account1, account2 = accesscontrol_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            account1,
+            accesscontrol.contract_address,
+            'renounceRole',
+            [
+                DEFAULT_ADMIN_ROLE,
+                account2.contract_address
+            ]
+        ),
+        reverted_with="AccessControl: can only renounce roles for self"
+    )
+
+
+@ pytest.mark.asyncio
+async def test_set_role_admin(accesscontrol_factory):
+    accesscontrol, account1, account2 = accesscontrol_factory
+
+    tx_exec_info = await signer.send_transaction(
+        account1,
+        accesscontrol.contract_address,
+        'setRoleAdmin',
+        [DEFAULT_ADMIN_ROLE, SOME_OTHER_ROLE]
+    )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=accesscontrol.contract_address,
+        name='RoleAdminChanged',
+        data=[
+            DEFAULT_ADMIN_ROLE,  # role
+            DEFAULT_ADMIN_ROLE,  # previousAdminRole
+            SOME_OTHER_ROLE      # newAdminRole
+        ]
+    )
+
+    expected = await accesscontrol.getRoleAdmin(DEFAULT_ADMIN_ROLE).execute()
+    assert expected.result.admin == SOME_OTHER_ROLE
+
+    # test role admin cycle
+    await signer.send_transaction(
+        account1,
+        accesscontrol.contract_address,
+        'grantRole',
+        [SOME_OTHER_ROLE, account2.contract_address]
+    )
+
+    expected = await accesscontrol.hasRole(SOME_OTHER_ROLE, account2.contract_address).execute()
+    assert expected.result.hasRole == TRUE
+
+    await signer.send_transaction(
+        account2,
+        accesscontrol.contract_address,
+        'revokeRole',
+        [DEFAULT_ADMIN_ROLE, account1.contract_address]
+    )
+
+    expected = await accesscontrol.hasRole(DEFAULT_ADMIN_ROLE, account1.contract_address).execute()
+    assert expected.result.hasRole == FALSE

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/test_Ownable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/access/test_Ownable.py
@@ -1,0 +1,63 @@
+import pytest
+from signers import MockSigner
+from nile.utils import assert_revert
+from utils import State, Account, get_contract_class, cached_contract
+from OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    return (
+        Account.get_class,
+        get_contract_class('Ownable')
+    )
+
+
+@pytest.fixture(scope='module')
+async def ownable_init(contract_classes):
+    account_cls, ownable_cls = contract_classes
+    starknet = await State.init()
+    owner = await Account.deploy(signer.public_key)
+    ownable = await starknet.deploy(
+        contract_class=ownable_cls,
+        constructor_calldata=[owner.contract_address]
+    )
+    not_owner = await Account.deploy(signer.public_key)
+    return starknet.state, ownable, owner, not_owner
+
+
+@pytest.fixture
+def contract_factory(contract_classes, ownable_init):
+    account_cls, ownable_cls = contract_classes
+    state, ownable, owner, not_owner = ownable_init
+    _state = state.copy()
+    owner = cached_contract(_state, account_cls, owner)
+    ownable = cached_contract(_state, ownable_cls, ownable)
+    not_owner = cached_contract(_state, account_cls, not_owner)
+    return ownable, owner, not_owner
+
+
+class TestOwnable(OwnableBase):
+    @pytest.mark.asyncio
+    async def test_contract_without_owner(self, contract_factory):
+        ownable, owner, _ = contract_factory
+        await signer.send_transaction(owner, ownable.contract_address, 'renounceOwnership', [])
+
+        # Protected function should not be called from zero address
+        await assert_revert(
+            ownable.protected_function().execute(),
+            reverted_with="Ownable: caller is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_contract_caller_not_owner(self, contract_factory):
+        ownable, owner, not_owner = contract_factory
+
+        # Protected function should only be called from owner
+        await assert_revert(
+            signer.send_transaction(not_owner, ownable.contract_address, 'protected_function', []),
+            reverted_with="Ownable: caller is not the owner"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_Account.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_Account.py
@@ -1,0 +1,243 @@
+import pytest
+from signers import MockSigner, get_raw_invoke
+from nile.utils import TRUE, assert_revert
+from utils import get_contract_class, cached_contract, State, Account, IACCOUNT_ID
+
+
+signer = MockSigner(123456789987654321)
+other = MockSigner(987654321123456789)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    init_cls = get_contract_class("Initializable")
+    attacker_cls = get_contract_class("AccountReentrancy")
+
+    return account_cls, init_cls, attacker_cls
+
+
+@pytest.fixture(scope='module')
+async def account_init(contract_classes):
+    _, init_cls, attacker_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+
+    initializable1 = await starknet.deploy(
+        contract_class=init_cls,
+        constructor_calldata=[],
+    )
+    initializable2 = await starknet.deploy(
+        contract_class=init_cls,
+        constructor_calldata=[],
+    )
+    attacker = await starknet.deploy(
+        contract_class=attacker_cls,
+        constructor_calldata=[],
+    )
+
+    return starknet.state, account1, account2, initializable1, initializable2, attacker
+
+
+@pytest.fixture
+def account_factory(contract_classes, account_init):
+    account_cls, init_cls, attacker_cls = contract_classes
+    state, account1, account2, initializable1, initializable2, attacker = account_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    initializable1 = cached_contract(_state, init_cls, initializable1)
+    initializable2 = cached_contract(_state, init_cls, initializable2)
+    attacker = cached_contract(_state, attacker_cls, attacker)
+
+    return account1, account2, initializable1, initializable2, attacker
+
+
+@pytest.mark.asyncio
+async def test_counterfactual_deployment(account_factory):
+    account, *_ = account_factory
+    await signer.declare_class(account, "Account")
+
+    execution_info = await signer.deploy_account(account.state, [signer.public_key])
+    address = execution_info.validate_info.contract_address
+
+    execution_info = await signer.send_transaction(account, address, 'getPublicKey', [])
+    assert execution_info.call_info.retdata[1] == signer.public_key
+
+
+@pytest.mark.asyncio
+async def test_constructor(account_factory):
+    account, *_ = account_factory
+
+    execution_info = await account.getPublicKey().call()
+    assert execution_info.result == (signer.public_key,)
+
+    execution_info = await account.supportsInterface(IACCOUNT_ID).call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_is_valid_signature(account_factory):
+    account, *_ = account_factory
+    hash = 0x23564
+    signature = signer.sign(hash)
+
+    execution_info = await account.isValidSignature(hash, signature).call()
+    assert execution_info.result == (TRUE,)
+
+    # should revert if signature is not correct
+    await assert_revert(
+        account.isValidSignature(hash + 1, signature).call(),
+        reverted_with=(
+            f"Signature {tuple(signature)}, is invalid, with respect to the public key {signer.public_key}, "
+            f"and the message hash {hash + 1}."
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_declare(account_factory):
+    account, *_ = account_factory
+
+    # regular declare works
+    await signer.declare_class(account, "ERC20")
+
+    # wrong signer fails
+    await assert_revert(
+        other.declare_class(account, "ERC20"),
+        reverted_with="is invalid, with respect to the public key"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (0,)
+
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
+
+    # wrong signer fails
+    await assert_revert(
+        other.send_transaction(account, initializable.contract_address, 'initialize', []),
+        reverted_with="is invalid, with respect to the public key"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multicall(account_factory):
+    account, _, initializable_1, initializable_2, _ = account_factory
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (0,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (0,)
+
+    await signer.send_transactions(
+        account,
+        [
+            (initializable_1.contract_address, 'initialize', []),
+            (initializable_2.contract_address, 'initialize', [])
+        ]
+    )
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (1,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_return_value(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    # initialize, set `initialized = 1`
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
+
+    read_info = await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
+    call_info = await initializable.initialized().call()
+    (call_result, ) = call_info.result
+    assert read_info.call_info.retdata[1] == call_result  # 1
+
+
+@ pytest.mark.asyncio
+async def test_nonce(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    # bump nonce
+    await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
+
+    # get nonce
+    args = [(initializable.contract_address, 'initialized', [])]
+    raw_invocation = get_raw_invoke(account, args)
+    current_nonce = await raw_invocation.state.state.get_nonce_at(account.contract_address)
+
+    # lower nonce
+    await assert_revert(
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce - 1),
+        reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
+            current_nonce, current_nonce - 1
+        )
+    )
+
+    # higher nonce
+    await assert_revert(
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce + 1),
+        reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
+            current_nonce, current_nonce + 1
+        )
+    )
+
+    # right nonce
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [], nonce=current_nonce)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (1,)
+
+
+@pytest.mark.asyncio
+async def test_public_key_setter(account_factory):
+    account, *_ = account_factory
+
+    execution_info = await account.getPublicKey().call()
+    assert execution_info.result == (signer.public_key,)
+
+    # set new pubkey
+    await signer.send_transaction(account, account.contract_address, 'setPublicKey', [other.public_key])
+
+    execution_info = await account.getPublicKey().call()
+    assert execution_info.result == (other.public_key,)
+
+
+@pytest.mark.asyncio
+async def test_public_key_setter_different_account(account_factory):
+    account, bad_account, *_ = account_factory
+
+    # set new pubkey
+    await assert_revert(
+        signer.send_transaction(bad_account, account.contract_address, 'setPublicKey', [other.public_key]),
+        reverted_with="Account: caller is not this account"
+    )
+
+
+@pytest.mark.asyncio
+async def test_account_takeover_with_reentrant_call(account_factory):
+    account, _, _, _, attacker = account_factory
+
+    await assert_revert(
+        signer.send_transaction(
+            account, attacker.contract_address, 'account_takeover', []),
+        reverted_with="Account: reentrant call"
+    )
+
+    execution_info = await account.getPublicKey().call()
+    assert execution_info.result == (signer.public_key,)
+
+
+async def test_interface():
+    assert get_contract_class("IAccount")

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_AddressRegistry.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_AddressRegistry.py
@@ -1,0 +1,58 @@
+import pytest
+from signers import MockSigner
+from utils import get_contract_class, cached_contract, State, Account
+
+
+signer = MockSigner(123456789987654321)
+L1_ADDRESS = 0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984
+ANOTHER_ADDRESS = 0xd9e1ce17f2641f24ae83637ab66a2cca9c378b9f
+
+@pytest.fixture(scope='module')
+async def registry_factory():
+    # contract classes
+    registry_cls = get_contract_class("AddressRegistry")
+    account_cls = Account.get_class
+
+    # deployments
+    starknet = await State.init()
+    account = await Account.deploy(signer.public_key)
+    registry = await starknet.deploy(
+        contract_class=registry_cls,
+        constructor_calldata=[]
+    )
+
+    # cache contracts
+    state = starknet.state.copy()
+    account = cached_contract(state, account_cls, account)
+    registry = cached_contract(state, registry_cls, registry)
+
+    return account, registry
+
+
+@pytest.mark.asyncio
+async def test_set_address(registry_factory):
+    account, registry = registry_factory
+
+    await signer.send_transaction(
+        account, registry.contract_address, 'set_L1_address', [L1_ADDRESS]
+    )
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+
+@pytest.mark.asyncio
+async def test_update_address(registry_factory):
+    account, registry = registry_factory
+
+    await signer.send_transaction(
+        account, registry.contract_address, 'set_L1_address', [L1_ADDRESS]
+    )
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (L1_ADDRESS,)
+
+    # set new address
+    await signer.send_transaction(
+        account, registry.contract_address, 'set_L1_address', [ANOTHER_ADDRESS]
+    )
+    execution_info = await registry.get_L1_address(account.contract_address).call()
+    assert execution_info.result == (ANOTHER_ADDRESS,)

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_EthAccount.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/account/test_EthAccount.py
@@ -1,0 +1,240 @@
+import pytest
+from nile.utils import assert_revert, TRUE, FALSE
+from utils import get_contract_class, cached_contract, State, IACCOUNT_ID
+from signers import MockEthSigner, get_raw_invoke
+
+private_key = b'\x01' * 32
+signer = MockEthSigner(b'\x01' * 32)
+other = MockEthSigner(b'\x02' * 32)
+
+
+@pytest.fixture(scope='module')
+def contract_defs():
+    account_cls = get_contract_class('EthAccount')
+    init_cls = get_contract_class("Initializable")
+    attacker_cls = get_contract_class("AccountReentrancy")
+
+    return account_cls, init_cls, attacker_cls
+
+
+@pytest.fixture(scope='module')
+async def account_init(contract_defs):
+    account_cls, init_cls, attacker_cls = contract_defs
+    starknet = await State.init()
+
+    account1 = await starknet.deploy(
+        contract_class=account_cls,
+        constructor_calldata=[signer.eth_address]
+    )
+    account2 = await starknet.deploy(
+        contract_class=account_cls,
+        constructor_calldata=[signer.eth_address]
+    )
+    initializable1 = await starknet.deploy(
+        contract_class=init_cls,
+        constructor_calldata=[],
+    )
+    initializable2 = await starknet.deploy(
+        contract_class=init_cls,
+        constructor_calldata=[],
+    )
+    attacker = await starknet.deploy(
+        contract_class=attacker_cls,
+        constructor_calldata=[],
+    )
+
+    return starknet.state, account1, account2, initializable1, initializable2, attacker
+
+
+@pytest.fixture
+def account_factory(contract_defs, account_init):
+    account_cls, init_cls, attacker_cls = contract_defs
+    state, account1, account2, initializable1, initializable2, attacker = account_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    initializable1 = cached_contract(_state, init_cls, initializable1)
+    initializable2 = cached_contract(_state, init_cls, initializable2)
+    attacker = cached_contract(_state, attacker_cls, attacker)
+
+    return account1, account2, initializable1, initializable2, attacker
+
+
+@pytest.mark.asyncio
+async def test_counterfactual_deployment(account_factory):
+    account, *_ = account_factory
+    await signer.declare_class(account, "EthAccount")
+
+    execution_info = await signer.deploy_account(account.state, [signer.eth_address])
+    address = execution_info.validate_info.contract_address
+
+    execution_info = await signer.send_transaction(account, address, 'getEthAddress', [])
+    assert execution_info.call_info.retdata[1] == signer.eth_address
+
+
+@pytest.mark.asyncio
+async def test_constructor(account_factory):
+    account, *_ = account_factory
+
+    execution_info = await account.getEthAddress().call()
+    assert execution_info.result == (signer.eth_address,)
+
+    execution_info = await account.supportsInterface(IACCOUNT_ID).call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_is_valid_signature(account_factory):
+    account, *_ = account_factory
+    hash = 0x23564
+    signature = signer.sign(hash)
+
+    execution_info = await account.isValidSignature(hash, signature).call()
+    assert execution_info.result == (TRUE,)
+
+    # should revert if signature is not correct
+    await assert_revert(
+        account.isValidSignature(hash + 1, signature).call(),
+        reverted_with="Invalid signature"
+    )
+
+
+@pytest.mark.asyncio
+async def test_declare(account_factory):
+    account, *_ = account_factory
+
+    # regular declare works
+    await signer.declare_class(account, "ERC20")
+
+    # wrong signer fails
+    await assert_revert(
+        other.declare_class(account, "ERC20"),
+        reverted_with="Invalid signature"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (FALSE,)
+
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (TRUE,)
+
+    # wrong signer fails
+    await assert_revert(
+        other.send_transaction(account, initializable.contract_address, 'initialize', []),
+        reverted_with="Invalid signature"
+    )
+
+
+@pytest.mark.asyncio
+async def test_multicall(account_factory):
+    account, _, initializable_1, initializable_2, _ = account_factory
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (FALSE,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (FALSE,)
+
+    await signer.send_transactions(
+        account,
+        [
+            (initializable_1.contract_address, 'initialize', []),
+            (initializable_2.contract_address, 'initialize', [])
+        ]
+    )
+
+    execution_info = await initializable_1.initialized().call()
+    assert execution_info.result == (TRUE,)
+    execution_info = await initializable_2.initialized().call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_return_value(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    # initialize, set `initialized = 1`
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [])
+
+    read_info = await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
+    call_info = await initializable.initialized().call()
+    (call_result, ) = call_info.result
+    assert read_info.call_info.retdata[1] == call_result  # 1
+
+
+@ pytest.mark.asyncio
+async def test_nonce(account_factory):
+    account, _, initializable, *_ = account_factory
+
+    # bump nonce
+    await signer.send_transaction(account, initializable.contract_address, 'initialized', [])
+
+    args = [(initializable.contract_address, 'initialized', [])]
+    raw_invocation = get_raw_invoke(account, args)
+    current_nonce = await raw_invocation.state.state.get_nonce_at(account.contract_address)
+
+    # lower nonce
+    await assert_revert(
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], current_nonce - 1),
+        reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
+            current_nonce, current_nonce - 1
+        )
+    )
+
+    # higher nonce
+    await assert_revert(
+        signer.send_transaction(account, initializable.contract_address, 'initialize', [], current_nonce + 1),
+        reverted_with="Invalid transaction nonce. Expected: {}, got: {}.".format(
+            current_nonce, current_nonce + 1
+        )
+    )
+
+    # right nonce
+    await signer.send_transaction(account, initializable.contract_address, 'initialize', [], current_nonce)
+
+    execution_info = await initializable.initialized().call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_eth_address_setter(account_factory):
+    account, *_ = account_factory
+
+    execution_info = await account.getEthAddress().call()
+    assert execution_info.result == (signer.eth_address,)
+
+    # set new pubkey
+    await signer.send_transaction(account, account.contract_address, 'setEthAddress', [other.eth_address])
+
+    execution_info = await account.getEthAddress().call()
+    assert execution_info.result == (other.eth_address,)
+
+
+@pytest.mark.asyncio
+async def test_eth_address_setter_different_account(account_factory):
+    account, bad_account, *_ = account_factory
+
+    # set new pubkey
+    await assert_revert(
+        signer.send_transaction(bad_account, account.contract_address, 'setEthAddress', [signer.eth_address]),
+        reverted_with="Account: caller is not this account"
+    )
+
+
+@pytest.mark.asyncio
+async def test_account_takeover_with_reentrant_call(account_factory):
+    account, _, _, _, attacker = account_factory
+
+    await assert_revert(
+        signer.send_transaction(account, attacker.contract_address, 'account_takeover', []),
+        reverted_with="Account: reentrant call"
+    )
+
+    execution_info = await account.getEthAddress().call()
+    assert execution_info.result == (signer.eth_address,)

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/conftest.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+import asyncio
+
+@pytest.fixture(scope='module')
+def event_loop():
+    return asyncio.new_event_loop()

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/introspection/test_ERC165.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/introspection/test_ERC165.py
@@ -1,0 +1,68 @@
+import pytest
+from nile.utils import assert_revert, TRUE, FALSE
+from utils import (
+    get_contract_class,
+    cached_contract,
+    State
+)
+
+
+# interface ids
+ERC165_ID = 0x01ffc9a7
+INVALID_ID = 0xffffffff
+OTHER_ID = 0x12345678
+
+
+@pytest.fixture
+async def erc165_factory():
+    # class
+    erc165_cls = get_contract_class("tests/mocks/ERC165.cairo", is_path=True)
+
+    # deployment
+    starknet = await State.init()
+    erc165 = await starknet.deploy(contract_class=erc165_cls)
+
+    # cache
+    state = starknet.state.copy()
+    erc165 = cached_contract(state, erc165_cls, erc165)
+    return erc165
+
+
+@pytest.mark.asyncio
+async def test_165_interface(erc165_factory):
+    erc165 = erc165_factory
+
+    execution_info = await erc165.supportsInterface(ERC165_ID).call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_invalid_id(erc165_factory):
+    erc165 = erc165_factory
+
+    execution_info = await erc165.supportsInterface(INVALID_ID).call()
+    assert execution_info.result == (FALSE,)
+
+
+@pytest.mark.asyncio
+async def test_register_interface(erc165_factory):
+    erc165 = erc165_factory
+
+    execution_info = await erc165.supportsInterface(OTHER_ID).call()
+    assert execution_info.result == (FALSE,)
+
+    # register interface
+    await erc165.registerInterface(OTHER_ID).execute()
+
+    execution_info = await erc165.supportsInterface(OTHER_ID).call()
+    assert execution_info.result == (TRUE,)
+
+
+@pytest.mark.asyncio
+async def test_register_invalid_interface(erc165_factory):
+    erc165 = erc165_factory
+
+    await assert_revert(
+        erc165.registerInterface(INVALID_ID).execute(),
+        reverted_with="ERC165: invalid interface id"
+    )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/AccessControl.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/AccessControl.cairo
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from openzeppelin.access.accesscontrol.library import AccessControl
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.utils.constants.library import DEFAULT_ADMIN_ROLE
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(admin: felt) {
+    AccessControl.initializer();
+    AccessControl._grant_role(DEFAULT_ADMIN_ROLE, admin);
+    return ();
+}
+
+@view
+func hasRole{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, user: felt
+) -> (hasRole: felt) {
+    let (hasRole) = AccessControl.has_role(role, user);
+    return (hasRole=hasRole);
+}
+
+@view
+func getRoleAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(role: felt) -> (
+    admin: felt
+) {
+    return AccessControl.get_role_admin(role);
+}
+
+@external
+func grantRole{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, user: felt
+) {
+    AccessControl.grant_role(role, user);
+    return ();
+}
+
+@external
+func revokeRole{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, user: felt
+) {
+    AccessControl.revoke_role(role, user);
+    return ();
+}
+
+@external
+func renounceRole{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, user: felt
+) {
+    AccessControl.renounce_role(role, user);
+    return ();
+}
+
+// ONLY FOR MOCKS, DON'T EXPOSE IN PRODUCTION
+@external
+func setRoleAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    role: felt, admin: felt
+) {
+    AccessControl._set_role_admin(role, admin);
+    return ();
+}
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/AccountReentrancy.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/AccountReentrancy.cairo
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import (
+    call_contract,
+    get_caller_address,
+)
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+
+from starkware.cairo.common.alloc import alloc
+
+const EXECUTE = 617075754465154585683856897856256838130216341506379215893724690153393808813;
+const SET_PUBLIC_KEY = 332268845949430430346835224631316185987738351560356300584998172574125127129;
+
+@external
+func account_takeover{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    alloc_locals;
+    let (caller) = get_caller_address();
+    let (call_calldata: felt*) = alloc();
+
+    // call_array
+    assert call_calldata[0] = 1;
+    assert call_calldata[1] = caller;
+    assert call_calldata[2] = SET_PUBLIC_KEY;
+    assert call_calldata[3] = 0;
+    assert call_calldata[4] = 1;
+
+    // calldata
+    assert call_calldata[5] = 1;
+    // new public key
+    assert call_calldata[6] = 123;
+
+
+    call_contract(
+        contract_address=caller, function_selector=EXECUTE, calldata_size=7, calldata=call_calldata
+    );
+
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC1155Mock.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC1155Mock.cairo
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+
+// This mock is to test functions from the ERC1155 library
+// that are not exposed in any preset like `setURI`
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc1155.library import ERC1155
+
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    uri: felt, owner: felt
+) {
+    ERC1155.initializer(uri);
+    return ();
+}
+
+@view
+func uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: Uint256) -> (
+    uri: felt
+) {
+    return ERC1155.uri(id);
+}
+
+
+@external
+func setURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(uri: felt) {
+    ERC1155._set_uri(uri);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC165.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC165.cairo
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+
+from openzeppelin.introspection.erc165.library import ERC165
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@external
+func registerInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) {
+    ERC165.register_interface(interfaceId);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC721SafeMintableMock.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ERC721SafeMintableMock.cairo
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.token.erc721.library import ERC721
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.access.ownable.library import Ownable
+
+//
+// Constructor
+//
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    name: felt, symbol: felt, owner: felt
+) {
+    ERC721.initializer(name, symbol);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+@view
+func name{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (name: felt) {
+    return ERC721.name();
+}
+
+@view
+func symbol{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (symbol: felt) {
+    return ERC721.symbol();
+}
+
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) -> (
+    balance: Uint256
+) {
+    return ERC721.balance_of(owner);
+}
+
+@view
+func ownerOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(tokenId: Uint256) -> (
+    owner: felt
+) {
+    return ERC721.owner_of(tokenId);
+}
+
+@view
+func getApproved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (approved: felt) {
+    return ERC721.get_approved(tokenId);
+}
+
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    owner: felt, operator: felt
+) -> (approved: felt) {
+    return ERC721.is_approved_for_all(owner, operator);
+}
+
+@view
+func tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenId: Uint256
+) -> (tokenURI: felt) {
+    let (tokenURI: felt) = ERC721.token_uri(tokenId);
+    return (tokenURI=tokenURI);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+@external
+func approve{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    ERC721.approve(to, tokenId);
+    return ();
+}
+
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    ERC721.set_approval_for_all(operator, approved);
+    return ();
+}
+
+@external
+func transferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256
+) {
+    ERC721.transfer_from(from_, to, tokenId);
+    return ();
+}
+
+@external
+func safeTransferFrom{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    from_: felt, to: felt, tokenId: Uint256, data_len: felt, data: felt*
+) {
+    ERC721.safe_transfer_from(from_, to, tokenId, data_len, data);
+    return ();
+}
+
+@external
+func mint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256
+) {
+    Ownable.assert_only_owner();
+    ERC721._mint(to, tokenId);
+    return ();
+}
+
+@external
+func safeMint{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    to: felt, tokenId: Uint256, data_len: felt, data: felt*
+) {
+    Ownable.assert_only_owner();
+    ERC721._safe_mint(to, tokenId, data_len, data);
+    return ();
+}
+
+@external
+func setTokenURI{pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, range_check_ptr}(
+    tokenId: Uint256, tokenURI: felt
+) {
+    Ownable.assert_only_owner();
+    ERC721._set_token_uri(tokenId, tokenURI);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Initializable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Initializable.cairo
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.security.initializable.library import Initializable
+
+@view
+func initialized{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (initialized: felt) {
+    return Initializable.initialized();
+}
+
+@external
+func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Initializable.initialize();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Ownable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Ownable.cairo
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+from openzeppelin.access.ownable.library import Ownable
+from starkware.cairo.common.bool import TRUE
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) {
+    Ownable.initializer(owner);
+    return ();
+}
+
+@external
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    new_owner: felt
+) {
+    Ownable.transfer_ownership(new_owner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}
+
+@external
+func protected_function{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    success: felt
+) {
+    Ownable.assert_only_owner();
+    return (success=TRUE);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Pausable.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/Pausable.cairo
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from openzeppelin.security.pausable.library import Pausable
+
+@storage_var
+func drastic_measure_taken() -> (success: felt) {
+}
+
+@storage_var
+func counter() -> (count: felt) {
+}
+
+@view
+func isPaused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    paused: felt
+) {
+    return Pausable.is_paused();
+}
+
+@view
+func getCount{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (count: felt) {
+    return counter.read();
+}
+
+@view
+func getDrasticMeasureTaken{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    success: felt
+) {
+    return drastic_measure_taken.read();
+}
+
+@external
+func normalProcess{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable.assert_not_paused();
+
+    let (currentCount) = counter.read();
+    counter.write(currentCount + 1);
+    return ();
+}
+
+@external
+func drasticMeasure{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable.assert_paused();
+
+    drastic_measure_taken.write(TRUE);
+    return ();
+}
+
+@external
+func pause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable._pause();
+    return ();
+}
+
+@external
+func unpause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Pausable._unpause();
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ProxiableImplementation.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ProxiableImplementation.cairo
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.upgrades.library import Proxy
+
+//
+// Storage
+//
+
+@storage_var
+func value() -> (val: felt) {
+}
+
+//
+// Initializer
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    proxy_admin: felt
+) {
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func getValue{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    return value.read();
+}
+
+@view
+func getAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    admin: felt
+) {
+    return Proxy.get_admin();
+}
+
+//
+// Setters
+//
+
+@external
+func setValue{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    value.write(val);
+    return ();
+}
+
+@external
+func setAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(address: felt) {
+    Proxy.assert_only_admin();
+    Proxy._set_admin(address);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ReentrancyAttackerMock.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ReentrancyAttackerMock.cairo
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import get_caller_address
+
+@contract_interface
+namespace IReentrancyGuard {
+    func callback() {
+    }
+}
+
+@external
+func call_sender{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (caller) = get_caller_address();
+    IReentrancyGuard.callback(contract_address=caller);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ReentrancyMock.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/ReentrancyMock.cairo
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.bool import TRUE
+from starkware.starknet.common.syscalls import get_contract_address
+
+from openzeppelin.security.reentrancyguard.library import ReentrancyGuard
+
+@contract_interface
+namespace IReentrancyGuardAttacker {
+    func call_sender() {
+    }
+}
+
+@contract_interface
+namespace IReentrancyGuard {
+    func count_this_recursive(n: felt) {
+    }
+}
+
+@storage_var
+func counter() -> (count: felt) {
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    initial_number: felt
+) {
+    counter.write(initial_number);
+    return ();
+}
+
+@view
+func current_count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    count: felt
+) {
+    return counter.read();
+}
+
+@external
+func callback{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    ReentrancyGuard.start();
+    _count();
+    ReentrancyGuard.end();
+    return ();
+}
+
+@external
+func count_local_recursive{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    n: felt
+) {
+    alloc_locals;
+    ReentrancyGuard.start();
+    let greater_zero = is_le(1, n);
+    if (greater_zero == TRUE) {
+        _count();
+        count_local_recursive(n - 1);
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+    ReentrancyGuard.end();
+    return ();
+}
+
+@external
+func count_this_recursive{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    n: felt
+) {
+    alloc_locals;
+    ReentrancyGuard.start();
+    let greater_zero = is_le(1, n);
+    if (greater_zero == TRUE) {
+        _count();
+        let (contract_address) = get_contract_address();
+        IReentrancyGuard.count_this_recursive(contract_address=contract_address, n=n - 1);
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    } else {
+        tempvar syscall_ptr = syscall_ptr;
+        tempvar pedersen_ptr = pedersen_ptr;
+        tempvar range_check_ptr = range_check_ptr;
+    }
+    ReentrancyGuard.end();
+    return ();
+}
+
+@external
+func count_and_call{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    attacker: felt
+) {
+    ReentrancyGuard.start();
+    _count();
+    IReentrancyGuardAttacker.call_sender(attacker);
+    ReentrancyGuard.end();
+    return ();
+}
+
+func _count{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    let (current_count) = counter.read();
+    counter.write(current_count + 1);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/SafeMathMock.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/SafeMathMock.cairo
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin, SignatureBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from openzeppelin.security.safemath.library import SafeUint256
+
+@view
+func uint256_add{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+    return SafeUint256.add(a, b);
+}
+
+@view
+func uint256_sub_le{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+    return SafeUint256.sub_le(a, b);
+}
+
+@view
+func uint256_sub_lt{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+    return SafeUint256.sub_lt(a, b);
+}
+
+@view
+func uint256_mul{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+    return SafeUint256.mul(a, b);
+}
+
+@view
+func uint256_div{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256) {
+    return SafeUint256.div_rem(a, b);
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/UpgradesMockV1.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/UpgradesMockV1.cairo
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.upgrades.library import Proxy, Proxy_initialized
+
+//
+// Storage
+//
+
+@storage_var
+func value_1() -> (val: felt) {
+}
+
+//
+// Initializer
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    proxy_admin: felt
+) {
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+@view
+func initialized{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() 
+-> (initialized: felt) {
+    let (initialized) = Proxy_initialized.read();
+    return (initialized=initialized);
+}
+
+//
+// Upgrades
+//
+
+@external
+func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    new_implementation: felt
+) {
+    Proxy.assert_only_admin();
+    Proxy._set_implementation_hash(new_implementation);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func getValue1{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    return value_1.read();
+}
+
+//
+// Setters
+//
+
+@external
+func setValue1{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    value_1.write(val);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/UpgradesMockV2.cairo
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/mocks/UpgradesMockV2.cairo
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+from openzeppelin.upgrades.library import Proxy
+
+//
+// Storage
+//
+
+@storage_var
+func value_1() -> (val: felt) {
+}
+
+@storage_var
+func value_2() -> (val: felt) {
+}
+
+//
+// Initializer
+//
+
+@external
+func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    proxy_admin: felt
+) {
+    Proxy.initializer(proxy_admin);
+    return ();
+}
+
+//
+// Upgrades
+//
+
+@external
+func upgrade{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    new_implementation: felt
+) {
+    Proxy.assert_only_admin();
+    Proxy._set_implementation_hash(new_implementation);
+    return ();
+}
+
+//
+// Getters
+//
+
+@view
+func getValue1{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    return value_1.read();
+}
+
+@view
+func getValue2{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (val: felt) {
+    return value_2.read();
+}
+
+@view
+func getImplementationHash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    implementation: felt
+) {
+    return Proxy.get_implementation_hash();
+}
+
+@view
+func getAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (admin: felt) {
+    return Proxy.get_admin();
+}
+
+//
+// Setters
+//
+
+@external
+func setValue1{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    value_1.write(val);
+    return ();
+}
+
+@external
+func setValue2{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(val: felt) {
+    value_2.write(val);
+    return ();
+}
+
+@external
+func setAdmin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(new_admin: felt) {
+    Proxy.assert_only_admin();
+    Proxy._set_admin(new_admin);
+    return ();
+}

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_initializable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_initializable.py
@@ -1,0 +1,24 @@
+import pytest
+from nile.utils import TRUE, FALSE, assert_revert
+from utils import get_contract_class, State
+
+
+@pytest.mark.asyncio
+async def test_initializer():
+    starknet = await State.init()
+    initializable = await starknet.deploy(
+        contract_class=get_contract_class("Initializable")
+    )
+    expected = await initializable.initialized().call()
+    assert expected.result == (FALSE,)
+
+    await initializable.initialize().execute()
+
+    expected = await initializable.initialized().call()
+    assert expected.result == (TRUE,)
+
+    # second initialize invocation should revert
+    await assert_revert(
+        initializable.initialize().execute(),
+        reverted_with="Initializable: contract already initialized"
+    )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_pausable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_pausable.py
@@ -1,0 +1,146 @@
+import pytest
+from signers import MockSigner
+from nile.utils import TRUE, FALSE, assert_revert
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted, State, Account
+)
+
+
+signer = MockSigner(12345678987654321)
+
+@pytest.fixture
+async def pausable_factory():
+    # class
+    pausable_cls = get_contract_class("Pausable")
+    account_cls = Account.get_class
+
+    # deploy
+    starknet = await State.init()
+    account = await Account.deploy(signer.public_key)
+    pausable = await starknet.deploy(
+        contract_class=pausable_cls,
+        constructor_calldata=[]
+    )
+    state = starknet.state.copy()
+
+    # cache
+    pausable = cached_contract(state, pausable_cls, pausable)
+    account = cached_contract(state, account_cls, account)
+
+    return pausable, account
+
+
+@pytest.mark.asyncio
+async def test_pausable_when_unpaused(pausable_factory):
+    contract, _ = pausable_factory
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.paused == FALSE
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.count == 0
+
+    # check that function executes when unpaused
+    await contract.normalProcess().execute()
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.count == 1
+
+    await assert_revert(
+        contract.drasticMeasure().execute(),
+        reverted_with="Pausable: not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_when_paused(pausable_factory):
+    contract, _ = pausable_factory
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.paused == FALSE
+
+    # pause
+    await contract.pause().execute()
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.paused == TRUE
+
+    await assert_revert(
+        contract.normalProcess().execute(),
+        reverted_with="Pausable: paused"
+    )
+
+    execution_info = await contract.getDrasticMeasureTaken().call()
+    assert execution_info.result.success == FALSE
+
+    # drastic measure
+    await contract.drasticMeasure().execute()
+
+    execution_info = await contract.getDrasticMeasureTaken().call()
+    assert execution_info.result.success == TRUE
+
+    # unpause
+    await contract.unpause().execute()
+
+    execution_info = await contract.isPaused().call()
+    assert execution_info.result.paused == FALSE
+
+    # check normal process after unpausing
+    await contract.normalProcess().execute()
+
+    execution_info = await contract.getCount().call()
+    assert execution_info.result.count == 1
+
+    await assert_revert(
+        contract.drasticMeasure().execute(),
+        reverted_with="Pausable: not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_pause_when_paused(pausable_factory):
+    contract, _ = pausable_factory
+
+    # pause
+    await contract.pause().execute()
+
+    # re-pause
+    await assert_revert(
+        contract.pause().execute(),
+        reverted_with="Pausable: paused"
+    )
+
+    # unpause
+    await contract.unpause().execute()
+
+    # re-unpause
+    await assert_revert(
+        contract.unpause().execute(),
+        reverted_with="Pausable: not paused"
+    )
+
+@pytest.mark.asyncio
+async def test_pausable_emits_events(pausable_factory):
+    contract, account = pausable_factory
+
+    # pause
+    tx_exec_info = await signer.send_transaction(
+        account, contract.contract_address, 'pause', []
+        )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=contract.contract_address,
+        name='Paused',
+        data=[account.contract_address]
+    )
+
+    # unpause
+    tx_exec_info = await signer.send_transaction(
+        account, contract.contract_address, 'unpause', []
+        )
+
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=contract.contract_address,
+        name='Unpaused',
+        data=[account.contract_address]
+    )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_reentrancy.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_reentrancy.py
@@ -1,0 +1,60 @@
+import pytest
+from nile.utils import assert_revert
+from utils import get_contract_class, State
+
+INITIAL_COUNTER = 0
+
+
+@pytest.fixture(scope='module')
+async def reentrancy_mock():
+    starknet = await State.init()
+    contract = await starknet.deploy(
+        contract_class=get_contract_class("ReentrancyMock"),
+        constructor_calldata=[INITIAL_COUNTER]
+    )
+
+    return contract, starknet
+
+
+@pytest.mark.asyncio
+async def test_reentrancy_guard_deploy(reentrancy_mock):
+    contract, _ = reentrancy_mock
+    response = await contract.current_count().call()
+
+    assert response.result == (INITIAL_COUNTER,)
+
+
+@pytest.mark.asyncio
+async def test_reentrancy_guard_remote_callback(reentrancy_mock):
+    contract, starknet = reentrancy_mock
+    attacker = await starknet.deploy("tests/mocks/ReentrancyAttackerMock.cairo")
+    # should not allow remote callback
+    await assert_revert(
+        contract.count_and_call(attacker.contract_address).execute(),
+        reverted_with="ReentrancyGuard: reentrant call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reentrancy_guard_local_recursion(reentrancy_mock):
+    contract, _ = reentrancy_mock
+    # should not allow local recursion
+    await assert_revert(
+        contract.count_local_recursive(10).execute(),
+        reverted_with="ReentrancyGuard: reentrant call"
+    )
+    # should not allow indirect local recursion
+    await assert_revert(
+        contract.count_this_recursive(10).execute(),
+        reverted_with="ReentrancyGuard: reentrant call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reentrancy_guard(reentrancy_mock):
+    contract, _ = reentrancy_mock
+    # should allow non reentrant call
+    await contract.callback().execute()
+    response = await contract.current_count().call()
+
+    assert response.result == (1,)

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_safemath.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/security/test_safemath.py
@@ -1,0 +1,206 @@
+import pytest
+from nile.utils import (
+    MAX_UINT256, assert_revert, add_uint, sub_uint,
+    mul_uint, div_rem_uint, to_uint
+)
+from utils import get_contract_class, State
+
+
+@pytest.fixture(scope='module')
+async def safemath_mock():
+    starknet = await State.init()
+    safemath = await starknet.deploy(
+        contract_class=get_contract_class("SafeMathMock")
+    )
+
+    return safemath
+
+
+@pytest.mark.asyncio
+async def test_add(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = add_uint(a, b)
+
+    execution_info = await safemath.uint256_add(a, b).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_add_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = to_uint(1)
+
+    await assert_revert(
+        safemath.uint256_add(a, b).execute(),
+        reverted_with="SafeUint256: addition overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_lt(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.uint256_sub_lt(a, b).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_lt_equal(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = MAX_UINT256
+
+    await assert_revert(
+        safemath.uint256_sub_lt(a, b).execute(),
+        reverted_with="SafeUint256: subtraction overflow or the difference equals zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_lt_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+
+    await assert_revert(
+        safemath.uint256_sub_lt(a, b).execute(),
+        reverted_with="SafeUint256: subtraction overflow or the difference equals zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sub_le(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(1234)
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.uint256_sub_le(a, b).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_le_equal(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = MAX_UINT256
+    c = sub_uint(a, b)
+
+    execution_info = await safemath.uint256_sub_le(a, b).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_sub_le_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+
+    await assert_revert(
+        safemath.uint256_sub_le(a, b).execute(),
+        reverted_with="SafeUint256: subtraction overflow"
+    )
+    await assert_revert(safemath.uint256_sub_le(a, b).execute())
+
+
+@pytest.mark.asyncio
+async def test_mul(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(1234)
+    b = to_uint(56789)
+    c = mul_uint(a, b)
+
+    execution_info = await safemath.uint256_mul(a, b).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_mul_zero(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(0)
+    b = to_uint(56789)
+    c = to_uint(0)
+
+    execution_info = await safemath.uint256_mul(a, b).execute()
+    assert execution_info.result == (c,)
+
+    execution_info = await safemath.uint256_mul(b, a).execute()
+    assert execution_info.result == (c,)
+
+
+@pytest.mark.asyncio
+async def test_mul_overflow(safemath_mock):
+    safemath = safemath_mock
+
+    a = MAX_UINT256
+    b = to_uint(2)
+
+    await assert_revert(
+        safemath.uint256_mul(a, b).execute(),
+        reverted_with="SafeUint256: multiplication overflow"
+    )
+
+
+@pytest.mark.asyncio
+async def test_div(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(56789)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.uint256_div(a, b).execute()
+    assert execution_info.result == (c, r)
+
+
+@pytest.mark.asyncio
+async def test_div_zero_dividend(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(0)
+    b = to_uint(56789)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.uint256_div(a, b).execute()
+    assert execution_info.result == (c, r)
+
+
+@pytest.mark.asyncio
+async def test_div_zero_divisor(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(56789)
+    b = to_uint(0)
+
+    await assert_revert(
+        safemath.uint256_div(a, b).execute(),
+        reverted_with="SafeUint256: divisor cannot be zero"
+    )
+
+
+@pytest.mark.asyncio
+async def test_div_uneven_division(safemath_mock):
+    safemath = safemath_mock
+
+    a = to_uint(7000)
+    b = to_uint(5678)
+    (c, r) = div_rem_uint(a, b)
+
+    execution_info = await safemath.uint256_div(a, b).execute()
+    assert execution_info.result == (c, r)

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/signers.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/signers.py
@@ -1,0 +1,215 @@
+from typing import Tuple
+from starkware.starknet.core.os.transaction_hash.transaction_hash import TransactionHashPrefix
+from starkware.starknet.core.os.contract_address.contract_address import (
+    calculate_contract_address_from_hash,
+)
+from starkware.starknet.definitions.general_config import StarknetChainId
+from starkware.starknet.services.api.gateway.transaction import InvokeFunction, DeployAccount
+from starkware.starknet.business_logic.transaction.objects import InternalTransaction, InternalDeclare, TransactionExecutionInfo
+from nile.signer import Signer, from_call_to_call_array, get_transaction_hash, TRANSACTION_VERSION
+from nile.utils import to_uint
+from utils import get_class_hash, get_contract_class
+import eth_keys
+
+
+class BaseSigner():
+    async def send_transaction(self, account, to, selector_name, calldata, nonce=None, max_fee=0):
+        return await self.send_transactions(account, [(to, selector_name, calldata)], nonce, max_fee)
+
+    async def send_transactions(
+        self,
+        account,
+        calls,
+        nonce=None,
+        max_fee=0
+    ) -> TransactionExecutionInfo:
+        raw_invocation = get_raw_invoke(account, calls)
+        state = raw_invocation.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(account.contract_address)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.INVOKE,
+            account=account.contract_address,
+            calldata=raw_invocation.calldata,
+            version=TRANSACTION_VERSION,
+            chain_id=StarknetChainId.TESTNET.value,
+            nonce=nonce,
+            max_fee=max_fee,
+        )
+
+        signature = self.sign(transaction_hash)
+
+        external_tx = InvokeFunction(
+            contract_address=account.contract_address,
+            calldata=raw_invocation.calldata,
+            entry_point_selector=None,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+        execution_info = await state.execute_tx(tx=tx)
+        return execution_info
+
+    async def declare_class(
+        self,
+        account,
+        contract_name,
+        nonce=None,
+        max_fee=0,
+    ) -> Tuple[int, TransactionExecutionInfo]:
+        state = account.state
+
+        if nonce is None:
+            nonce = await state.state.get_nonce_at(contract_address=account.contract_address)
+
+        contract_class = get_contract_class(contract_name)
+        class_hash = get_class_hash(contract_name)
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.DECLARE,
+            account=account.contract_address,
+            calldata=[class_hash],
+            nonce=nonce,
+            version=TRANSACTION_VERSION,
+            max_fee=max_fee,
+            chain_id=StarknetChainId.TESTNET.value
+        )
+
+        signature = self.sign(transaction_hash)
+
+        tx = InternalDeclare.create(
+            sender_address=account.contract_address,
+            contract_class=contract_class,
+            chain_id=StarknetChainId.TESTNET.value,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+            signature=signature,
+        )
+
+        execution_info = await state.execute_tx(tx=tx)
+
+        await state.state.set_contract_class(
+            class_hash=tx.class_hash,
+            contract_class=contract_class
+        )
+        return class_hash, execution_info
+
+    async def deploy_account(
+        self,
+        state,
+        calldata,
+        salt=0,
+        nonce=0,
+        max_fee=0,
+    ) -> TransactionExecutionInfo:
+        account_address = calculate_contract_address_from_hash(
+            salt=salt,
+            class_hash=self.class_hash,
+            constructor_calldata=calldata,
+            deployer_address=0
+        )
+
+        transaction_hash = get_transaction_hash(
+            prefix=TransactionHashPrefix.DEPLOY_ACCOUNT,
+            account=account_address,
+            calldata=[self.class_hash, salt, *calldata],
+            nonce=nonce,
+            version=TRANSACTION_VERSION,
+            max_fee=max_fee,
+            chain_id=StarknetChainId.TESTNET.value
+        )
+
+        signature = self.sign(transaction_hash)
+
+        external_tx = DeployAccount(
+            class_hash=self.class_hash,
+            contract_address_salt=salt,
+            constructor_calldata=calldata,
+            signature=signature,
+            max_fee=max_fee,
+            version=TRANSACTION_VERSION,
+            nonce=nonce,
+        )
+
+        tx = InternalTransaction.from_external(
+            external_tx=external_tx, general_config=state.general_config
+        )
+
+        execution_info = await state.execute_tx(tx=tx)
+        return execution_info
+
+class MockSigner(BaseSigner):
+    """
+    Utility for sending signed transactions to an Account on Starknet.
+
+    Parameters
+    ----------
+
+    private_key : int
+
+    Examples
+    ---------
+    Constructing a MockSigner object
+
+    >>> signer = MockSigner(1234)
+
+    Sending a transaction
+
+    >>> await signer.send_transaction(
+            account, contract_address, 'contract_method', [arg_1]
+        )
+
+    Sending multiple transactions
+
+    >>> await signer.send_transactions(
+            account, [
+                (contract_address, 'contract_method', [arg_1]),
+                (contract_address, 'another_method', [arg_1, arg_2])
+            ]
+        )
+
+    """
+    def __init__(self, private_key):
+        self.signer = Signer(private_key)
+        self.public_key = self.signer.public_key
+        self.class_hash = get_class_hash("Account")
+
+    def sign(self, transaction_hash):
+        sig_r, sig_s = self.signer.sign(transaction_hash)
+        return [sig_r, sig_s]
+
+
+class MockEthSigner(BaseSigner):
+    """
+    Utility for sending signed transactions to an Account on Starknet, like MockSigner, but using a secp256k1 signature.
+    Parameters
+    ----------
+    private_key : int
+
+    """
+    def __init__(self, private_key):
+        self.signer = eth_keys.keys.PrivateKey(private_key)
+        self.eth_address = int(self.signer.public_key.to_checksum_address(), 0)
+        self.class_hash = get_class_hash("EthAccount")
+
+    def sign(self, transaction_hash):
+        signature = self.signer.sign_msg_hash(
+            (transaction_hash).to_bytes(32, byteorder="big"))
+        sig_r = to_uint(signature.r)
+        sig_s = to_uint(signature.s)
+        return [signature.v, *sig_r, *sig_s]
+
+
+def get_raw_invoke(sender, calls):
+    """Return raw invoke, remove when test framework supports `invoke`."""
+    call_array, calldata = from_call_to_call_array(calls)
+    raw_invocation = sender.__execute__(call_array, calldata)
+    return raw_invocation

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/test_signers.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/test_signers.py
@@ -1,0 +1,72 @@
+import pytest
+
+from signers import MockSigner
+from utils import (
+    State,
+    Account,
+    get_contract_class,
+    cached_contract,
+    FALSE,
+    TRUE,
+)
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    deployer_cls = get_contract_class('UniversalDeployer')
+
+    return account_cls, deployer_cls
+
+
+@pytest.fixture(scope='module')
+async def deployer_init(contract_classes):
+    _, deployer_cls = contract_classes
+    starknet = await State.init()
+    account = await Account.deploy(signer.public_key)
+    deployer = await starknet.deploy(contract_class=deployer_cls)
+    return (
+        starknet.state,
+        account,
+        deployer
+    )
+
+
+@pytest.fixture
+def deployer_factory(contract_classes, deployer_init):
+    account_cls, deployer_cls = contract_classes
+    state, account, deployer = deployer_init
+    _state = state.copy()
+    _account = cached_contract(_state, account_cls, account)
+    deployer = cached_contract(_state, deployer_cls, deployer)
+
+    return _account, deployer
+
+
+@pytest.mark.asyncio
+async def test_signer_declare_class(deployer_factory):
+    account, deployer = deployer_factory
+    salt = 1234567875432  # random value
+    unique = 0
+    calldata = []
+
+    # declare contract class
+    class_hash, _ = await signer.declare_class(account, "Initializable")
+
+    # deploy contract
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+    deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
+    deployed_address = deploy_exec_info.call_info.retdata[1]
+
+    # test deployment
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == FALSE
+
+    await signer.send_transaction(account, deployed_address, 'initialize', [])
+
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'initialized', [])
+    is_initialized = tx_exec_info.call_info.retdata[1]
+    assert is_initialized == TRUE

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/ERC1155BaseSuite.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/ERC1155BaseSuite.py
@@ -1,0 +1,811 @@
+import pytest
+from signers import MockSigner
+from utils import assert_event_emitted
+
+from nile.utils import (
+    MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256, TRUE, FALSE,
+    to_uint, add_uint, sub_uint, assert_revert, str_to_felt
+)
+
+signer = MockSigner(123456789987654321)
+
+#
+# Helpers
+#
+
+
+def to_uint_array(arr):
+    return list(map(to_uint, arr))
+
+
+def prepare_calldata(arr):
+    """Flatten an array of tuples or an array of ints."""
+    # [5, 5, 5]        => [3, 5, 5, 5]
+    # [(1, 2), (3, 4)] => [2, 1, 2, 3, 4]
+    res = [len(arr)]
+    if res[0] == 0:
+        return res
+    if type(arr[0]) == int:
+        return res + arr
+    if type(arr[0]) == tuple:
+        for elem in arr:
+            res += [*elem]
+        return res
+    raise Exception
+
+#
+# Constants
+#
+
+NOT_BOOLEAN = 3
+ACCOUNT = 123
+TOKEN_ID = to_uint(111)
+MINT_VALUE = to_uint(1000)
+TRANSFER_VALUE = to_uint(500)
+
+ACCOUNTS = [123, 234, 345]
+TOKEN_IDS = [TOKEN_ID, to_uint(222), to_uint(333)]
+MINT_VALUES = [MINT_VALUE, to_uint(2000), to_uint(3000)]
+TRANSFER_VALUES = [TRANSFER_VALUE, to_uint(1000), to_uint(1500)]
+TRANSFER_DIFFERENCES = [sub_uint(m, t)
+                        for m, t in zip(MINT_VALUES, TRANSFER_VALUES)]
+MAX_UINT_VALUES = [to_uint(1), MAX_UINT256, to_uint(1)]
+INVALID_VALUES = [to_uint(1), (MAX_UINT256[0]+1, MAX_UINT256[1]), to_uint(1)]
+INVALID_IDS = [to_uint(111),INVALID_UINT256,to_uint(333)]
+
+DEFAULT_URI = str_to_felt('mock://mytoken.v1')
+NEW_URI = str_to_felt('mock://mytoken.v2')
+
+DATA = 0
+REJECT_DATA = [1, 0]
+
+IERC165_ID = int('0x01ffc9a7', 16)
+IERC1155_ID = int('0xd9b67a26', 16)
+IERC1155_MetadataURI = int('0x0e89341c', 16)
+ERC165_UNSUPPORTED = int('0xffffffff', 16)
+UNSUPPORTED_ID = int('0xaabbccdd', 16)
+
+SUPPORTED_INTERFACES = [IERC165_ID, IERC1155_ID, IERC1155_MetadataURI]
+UNSUPPORTED_INTERFACES = [ERC165_UNSUPPORTED, UNSUPPORTED_ID]
+
+
+class ERC1155Base:
+    #
+    # Constructor
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_constructor(self, contract_factory):
+        erc1155, _, _, _ = contract_factory
+
+        execution_info = await erc1155.uri(TOKEN_ID).execute()
+        assert execution_info.result.uri == DEFAULT_URI
+
+    #
+    # ERC165
+    #
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("supported_id", SUPPORTED_INTERFACES)
+    async def test_supports_interface(self, contract_factory, supported_id):
+        erc1155, _, _, _ = contract_factory
+
+        execution_info = await erc1155.supportsInterface(supported_id).execute()
+        assert execution_info.result.success == TRUE
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("unsupported_id", UNSUPPORTED_INTERFACES)
+    async def test_supports_interface_unsupported(self, contract_factory, unsupported_id):
+        erc1155, _, _, _ = contract_factory
+
+        execution_info = await erc1155.supportsInterface(unsupported_id).execute()
+        assert execution_info.result.success == FALSE
+
+    #
+    # Set/Get approval
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_set_approval_for_all(self, contract_factory):
+        erc1155, account, _, _ = contract_factory
+
+        approver = account.contract_address
+
+        # Set approval
+        await signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [ACCOUNT, TRUE]
+        )
+
+        execution_info = await erc1155.isApprovedForAll(
+            approver, ACCOUNT).execute()
+
+        assert execution_info.result.approved == TRUE
+
+        # Unset approval
+        await signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [ACCOUNT, FALSE]
+        )
+
+        execution_info = await erc1155.isApprovedForAll(
+            approver, ACCOUNT).execute()
+
+        assert execution_info.result.approved == FALSE
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("approval", [TRUE, FALSE])
+    async def test_set_approval_for_all_emits_event(self, contract_factory, approval):
+        erc1155, account, _, _ = contract_factory
+
+        execution_info = await signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [ACCOUNT, approval]
+        )
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='ApprovalForAll',
+            data=[
+                account.contract_address,
+                ACCOUNT,
+                approval
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_set_approval_for_all_non_boolean(self, contract_factory):
+        erc1155, account, _, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [ACCOUNT, NOT_BOOLEAN]), 
+            "ERC1155: approval is not boolean")
+
+
+    @pytest.mark.asyncio
+    async def test_set_approval_for_all_self(self, contract_factory):
+        erc1155, account, _, _ = contract_factory
+
+        approvee = account.contract_address
+
+        # Set approval
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [approvee, TRUE]),
+            "ERC1155: setting approval status for self")
+
+
+    @pytest.mark.asyncio
+    async def test_set_approval_for_all_zero_address(self, contract_factory):
+        erc1155, account, _, _ = contract_factory
+
+        # Set approval
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'setApprovalForAll',
+            [ZERO_ADDRESS, TRUE]),
+            "ERC1155: setting approval status for zero address")
+
+    #
+    # Balance getters
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        user = account.contract_address
+
+        execution_info = await erc1155.balanceOf(user, TOKEN_ID).execute()
+        assert execution_info.result.balance == MINT_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of_zero_address(self, contract_factory):
+        erc1155, _, _, _ = contract_factory
+
+        await assert_revert(
+            erc1155.balanceOf(ZERO_ADDRESS, TOKEN_ID).execute(),
+            "ERC1155: address zero is not a valid owner")
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of_invalid_id(self, contract_factory):
+        erc1155, _, _, _ = contract_factory
+
+        await assert_revert(
+            erc1155.balanceOf(ACCOUNT, INVALID_UINT256).execute(),
+            "ERC1155: token_id is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of_batch(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        accounts = [account.contract_address]*3
+
+        execution_info = await erc1155.balanceOfBatch(accounts, TOKEN_IDS).execute()
+        assert execution_info.result.balances == MINT_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of_batch_zero_address(self, contract_factory):
+        erc1155, _, _, _ = contract_factory
+        accounts = [ACCOUNT, ZERO_ADDRESS, ACCOUNT]
+
+        await assert_revert(
+            erc1155.balanceOfBatch(accounts, TOKEN_IDS).execute(),
+            "ERC1155: address zero is not a valid owner")
+
+
+    @pytest.mark.asyncio
+    async def test_balance_of_batch_invalid_id(self, contract_factory):
+        erc1155, _, _, _ = contract_factory
+
+        accounts = [ACCOUNT]*3
+
+        await assert_revert(
+            erc1155.balanceOfBatch(accounts, INVALID_IDS).execute(),
+            "ERC1155: token_id is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "accounts,ids",
+        [(ACCOUNTS[:2], TOKEN_IDS), (ACCOUNTS, TOKEN_IDS[:2])])
+    async def test_balance_of_batch_uneven_arrays(self, contract_factory, accounts, ids):
+        erc1155, _, _, _ = contract_factory
+
+        await assert_revert(
+            erc1155.balanceOfBatch(accounts, ids).execute(),
+            "ERC1155: accounts and ids length mismatch")
+
+    #
+    # Transfer
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA])
+
+        execution_info = await erc1155.balanceOf(sender, TOKEN_ID).execute()
+        assert execution_info.result.balance == sub_uint(
+            MINT_VALUE, TRANSFER_VALUE)
+
+        execution_info = await erc1155.balanceOf(recipient, TOKEN_ID).execute()
+        assert execution_info.result.balance == TRANSFER_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_emits_event(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        execution_info = await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferSingle',
+            data=[
+                sender,     # operator
+                sender,     # from
+                recipient,  # to
+                *TOKEN_ID,
+                *TRANSFER_VALUE
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_approved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        operator = account1.contract_address
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        # account2 approves account1
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        # account sends transaction
+        await signer.send_transaction(
+            account1, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA])
+
+        execution_info = await erc1155.balanceOf(sender, TOKEN_ID).execute()
+        assert execution_info.result.balance == sub_uint(
+            MINT_VALUE, TRANSFER_VALUE)
+
+        execution_info = await erc1155.balanceOf(recipient, TOKEN_ID).execute()
+        assert execution_info.result.balance == TRANSFER_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_approved_emits_event(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        operator = account1.contract_address
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        # account1/operator sends transaction
+        execution_info = await signer.send_transaction(
+            account1, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferSingle',
+            data=[
+                operator,   # operator
+                sender,     # from
+                recipient,  # to
+                *TOKEN_ID,
+                *TRANSFER_VALUE
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_invalid_value(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        sender = account.contract_address
+        recipient = owner.contract_address
+
+        # mint max uint to avoid possible insufficient balance error
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [sender, *TOKEN_ID, *MAX_UINT256, DATA])
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'safeTransferFrom',
+                [sender, recipient, *TOKEN_ID, *INVALID_UINT256, DATA]),
+            "ERC1155: value is not a valid Uint256"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_invalid_id(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        sender = account.contract_address
+        recipient = owner.contract_address
+
+        # transfer 0 value of invalid id to avoid
+        # insufficient balance error
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'safeTransferFrom',
+                [sender, recipient, *INVALID_UINT256, *to_uint(0), DATA]),
+            "ERC1155: token_id is not a valid Uint256"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_insufficient_balance(self, minted_factory):
+        erc1155, account, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account.contract_address
+
+        transfer_value = add_uint(MINT_VALUES[0], to_uint(1))
+
+        await assert_revert(
+            signer.send_transaction(
+                account2, erc1155.contract_address, 'safeTransferFrom',
+                [sender, recipient, *TOKEN_ID, *transfer_value, DATA]),
+            "ERC1155: insufficient balance for transfer"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_unapproved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account1, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA]),
+            "ERC1155: caller is not owner nor approved")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_to_zero_address(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        sender = account.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeTransferFrom',
+            [sender, ZERO_ADDRESS, *TOKEN_ID, *TRANSFER_VALUE, DATA]),
+            "ERC1155: transfer to the zero address")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_overflow(self, minted_factory):
+        erc1155, owner, account, _ = minted_factory
+
+        sender = account.contract_address
+        recipient = owner.contract_address
+
+        # Bring recipient's balance to max possible
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [recipient, *TOKEN_ID, *MAX_UINT256, DATA])
+
+        # Issuing recipient any more should revert due to overflow
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *to_uint(1), DATA]),
+            "ERC1155: balance overflow")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_to_receiver(self, minted_factory):
+        erc1155, _, account2, receiver = minted_factory
+
+        sender = account2.contract_address
+        recipient = receiver.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA])
+
+        execution_info = await erc1155.balanceOf(recipient, TOKEN_ID).execute()
+        assert execution_info.result.balance == TRANSFER_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_to_receiver_rejection(self, minted_factory):
+        erc1155, _, account2, receiver = minted_factory
+
+        sender = account2.contract_address
+        recipient = receiver.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account2, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, *REJECT_DATA]),
+            "ERC1155: ERC1155Receiver rejected tokens")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_transfer_from_to_non_receiver(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        sender = account.contract_address
+        recipient = erc1155.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeTransferFrom',
+            [sender, recipient, *TOKEN_ID, *TRANSFER_VALUE, DATA]),
+            "ERC1155: transfer to non-ERC1155Receiver implementer")
+
+
+    #
+    # Batch Transfers
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [sender]*3+[recipient]*3, TOKEN_IDS*2).execute()
+        assert execution_info.result.balances[:3] == TRANSFER_DIFFERENCES
+        assert execution_info.result.balances[3:] == TRANSFER_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_emits_event(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        execution_info = await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferBatch',
+            data=[
+                sender,     # operator
+                sender,     # from
+                recipient,  # to
+                *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES),
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_approved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        operator = account1.contract_address
+        recipient = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        await signer.send_transaction(
+            account1, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [sender]*3+[recipient]*3, TOKEN_IDS*2).execute()
+        assert execution_info.result.balances[:3] == TRANSFER_DIFFERENCES
+        assert execution_info.result.balances[3:] == TRANSFER_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_approved_emits_event(self, 
+            minted_factory):
+        erc1155, account1, account2, receiver = minted_factory
+
+        sender = account2.contract_address
+        operator = account1.contract_address
+        recipient = receiver.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        execution_info = await signer.send_transaction(
+            account1, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferBatch',
+            data=[
+                operator,   # operator
+                sender,     # from
+                recipient,  # to
+                *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES),
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_invalid_value(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        sender = account.contract_address
+        recipient = owner.contract_address
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [sender, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MAX_UINT_VALUES), DATA])
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(INVALID_VALUES), DATA
+            ]),
+            "ERC1155: value is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_invalid_id(self, minted_factory):
+        erc1155, owner, account, _ = minted_factory
+
+        sender = account.contract_address
+        recipient = owner.contract_address
+        transfer_values = [to_uint(0)]*3
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'safeBatchTransferFrom',
+                [
+                    sender, recipient, *prepare_calldata(INVALID_IDS),
+                    *prepare_calldata(transfer_values), DATA
+                ]),
+            "ERC1155: token_id is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_insufficient_balance(self, 
+            minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        values = values = MINT_VALUES.copy()
+        values[1] = add_uint(values[1], to_uint(1))
+
+        await assert_revert(signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [sender, recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(values), DATA]),
+            "ERC1155: insufficient balance for transfer")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_unapproved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account1, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ]),
+            "ERC1155: caller is not owner nor approved")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_to_zero_address(self, 
+            minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        sender = account.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, ZERO_ADDRESS, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ]),
+            "ERC1155: transfer to the zero address")
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "values,token_ids",
+        [
+            (TRANSFER_VALUES[:2], TOKEN_IDS),
+            (TRANSFER_VALUES, TOKEN_IDS[:2])
+        ]
+    )
+    async def test_safe_batch_transfer_from_uneven_arrays(self, 
+            minted_factory, values, token_ids):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [sender, recipient, *prepare_calldata(token_ids), *prepare_calldata(values), DATA]),
+            "ERC1155: ids and values length mismatch")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_overflow(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        sender = account2.contract_address
+        recipient = account1.contract_address
+        transfer_values = to_uint_array([0, 1, 0])
+
+        # Bring 1 recipient's balance to max possible
+        await signer.send_transaction(
+            account1, erc1155.contract_address, 'mintBatch',
+            [recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MAX_UINT_VALUES), DATA]
+        )
+
+        # Issuing recipient any more on just 1 token_id
+        # should revert due to overflow
+        await assert_revert(signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(transfer_values), DATA
+            ]),
+            "ERC1155: balance overflow")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_to_receiver(self, minted_factory):
+        erc1155, _, account2, receiver = minted_factory
+
+        sender = account2.contract_address
+        recipient = receiver.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [sender]*3+[recipient]*3, TOKEN_IDS*2).execute()
+        assert execution_info.result.balances[:3] == TRANSFER_DIFFERENCES
+        assert execution_info.result.balances[3:] == TRANSFER_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_to_receiver_rejection(self, 
+            minted_factory):
+        erc1155, _, account2, receiver = minted_factory
+
+        sender = account2.contract_address
+        recipient = receiver.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account2, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), *REJECT_DATA
+            ]),
+            "ERC1155: ERC1155Receiver rejected tokens")
+
+
+    @pytest.mark.asyncio
+    async def test_safe_batch_transfer_from_to_non_receiver(self, 
+            minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        sender = account.contract_address
+        recipient = erc1155.contract_address
+
+        await assert_revert(signer.send_transaction(
+            account, erc1155.contract_address, 'safeBatchTransferFrom',
+            [
+                sender, recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(TRANSFER_VALUES), DATA
+            ]),
+            "ERC1155: transfer to non-ERC1155Receiver implementer")

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/test_ERC1155Internals.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/test_ERC1155Internals.py
@@ -1,0 +1,67 @@
+import pytest
+from signers import MockSigner
+from utils import State, Account, get_contract_class, cached_contract
+
+from ERC1155BaseSuite import TOKEN_ID, NEW_URI, DEFAULT_URI
+
+signer = MockSigner(123456789987654321)
+
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc1155_cls = get_contract_class('ERC1155Mock')
+    return account_cls, erc1155_cls
+
+
+@pytest.fixture(scope='module')
+async def erc1155_init(contract_classes):
+    _, erc1155_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc1155 = await starknet.deploy(
+        contract_class=erc1155_cls,
+        constructor_calldata=[DEFAULT_URI, account1.contract_address]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc1155,
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc1155_init):
+    account_cls, erc1155_cls = contract_classes
+    state, account1, account2, erc1155 = erc1155_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc1155 = cached_contract(_state, erc1155_cls, erc1155)
+    return erc1155, account1, account2
+
+
+class TestERC1155Internals():
+    #
+    # Set URI
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_set_uri(self, contract_factory):
+        erc1155, owner, _ = contract_factory
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'setURI',
+            [NEW_URI]
+        )
+
+        execution_info = await erc1155.uri(TOKEN_ID).execute()
+        assert execution_info.result.uri == NEW_URI

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/test_ERC1155MintableBurnable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc1155/test_ERC1155MintableBurnable.py
@@ -1,0 +1,723 @@
+import pytest
+from signers import MockSigner
+from utils import State, Account, get_contract_class, cached_contract, assert_event_emitted
+
+from access.OwnableBaseSuite import OwnableBase
+from ERC1155BaseSuite import (
+    ERC1155Base, to_uint_array, prepare_calldata,
+    TOKEN_ID, MINT_VALUE,
+    MINT_VALUE,TOKEN_IDS,
+    MINT_VALUES, MAX_UINT_VALUES,
+    INVALID_VALUES, INVALID_IDS,
+    DATA, REJECT_DATA, DEFAULT_URI
+)
+
+from nile.utils import (
+    MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256, TRUE, FALSE,
+    to_uint, add_uint, sub_uint, assert_revert
+)
+
+signer = MockSigner(123456789987654321)
+
+#
+# Constants
+#
+BURN_value = to_uint(500)
+BURN_VALUES = [BURN_value, to_uint(1000), to_uint(1500)]
+BURN_DIFFERENCES = [sub_uint(m, b) for m, b in zip(MINT_VALUES, BURN_VALUES)]
+
+#
+# Fixtures
+#
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc1155_cls = get_contract_class('ERC1155MintableBurnable')
+    receiver_cls = get_contract_class('ERC1155Holder')
+    return account_cls, erc1155_cls, receiver_cls
+
+
+@pytest.fixture(scope='module')
+async def erc1155_init(contract_classes):
+    _, erc1155_cls, receiver_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc1155 = await starknet.deploy(
+        contract_class=erc1155_cls,
+        constructor_calldata=[DEFAULT_URI, account1.contract_address]
+    )
+    receiver = await starknet.deploy(
+        contract_class=receiver_cls
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc1155,
+        receiver
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc1155_init):
+    account_cls, erc1155_cls, receiver_cls = contract_classes
+    state, account1, account2, erc1155, receiver = erc1155_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc1155 = cached_contract(_state, erc1155_cls, erc1155)
+    receiver = cached_contract(_state, receiver_cls, receiver)
+    return erc1155, account1, account2, receiver
+
+
+@pytest.fixture
+async def minted_factory(contract_classes, erc1155_init):
+    account_cls, erc1155_cls, receiver_cls = contract_classes
+    state, owner, account, erc1155, receiver = erc1155_init
+    _state = state.copy()
+    owner = cached_contract(_state, account_cls, owner)
+    account = cached_contract(_state, account_cls, account)
+    erc1155 = cached_contract(_state, erc1155_cls, erc1155)
+    receiver = cached_contract(_state, receiver_cls, receiver)
+    await signer.send_transaction(
+        owner, erc1155.contract_address, 'mintBatch',
+        [
+            account.contract_address,         # to
+            *prepare_calldata(TOKEN_IDS),     # ids
+            *prepare_calldata(MINT_VALUES),   # values
+            DATA
+        ]
+    )
+    return erc1155, owner, account, receiver
+
+
+
+class TestERC1155MintableBurnable(ERC1155Base, OwnableBase):
+    #
+    # Minting
+    #
+
+    @pytest.mark.asyncio
+    async def test_mint(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [recipient, *TOKEN_ID, *MINT_VALUE, DATA])
+
+        execution_info = await erc1155.balanceOf(recipient, TOKEN_ID).execute()
+        assert execution_info.result.balance == MINT_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_mint_emits_event(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        execution_info = await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [recipient, *TOKEN_ID, *MINT_VALUE, DATA])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferSingle',
+            data=[
+                owner.contract_address,  # operator
+                ZERO_ADDRESS,            # from
+                recipient,               # to
+                *TOKEN_ID,
+                *MINT_VALUE
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_zero_address(self, contract_factory):
+        erc1155, owner, _, _ = contract_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mint',
+                [ZERO_ADDRESS, *TOKEN_ID, *MINT_VALUE, DATA]),
+            "ERC1155: mint to the zero address")
+
+
+    @pytest.mark.asyncio
+    async def test_mint_overflow(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        # Bring recipient's balance to max possible
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [recipient, *TOKEN_ID, *MAX_UINT256, DATA])
+
+        # Issuing recipient any more should revert due to overflow
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mint',
+                [recipient, *TOKEN_ID, *to_uint(1), DATA]),
+            "ERC1155: balance overflow")
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "value,token_id,error",
+        [
+            (MINT_VALUE, INVALID_UINT256,
+            "ERC1155: token_id is not a valid Uint256"),
+            (INVALID_UINT256, TOKEN_ID, 
+            "ERC1155: value is not a valid Uint256")
+        ]
+    )
+    async def test_mint_invalid_uint(self, contract_factory, value, token_id, error):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mint',
+                [recipient, *token_id, *value, DATA]),
+            error)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_receiver(self, contract_factory):
+        erc1155, owner, _, receiver = contract_factory
+
+        recipient = receiver.contract_address
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [recipient, *TOKEN_ID, *MINT_VALUE, DATA])
+
+        execution_info = await erc1155.balanceOf(
+            recipient, TOKEN_ID).execute()
+        assert execution_info.result.balance == MINT_VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_mint_receiver_rejection(self, contract_factory):
+        erc1155, owner, _, receiver = contract_factory
+
+        recipient = receiver.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mint',
+                [recipient, *TOKEN_ID, *MINT_VALUE, *REJECT_DATA]),
+            "ERC1155: ERC1155Receiver rejected tokens")
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_unsafe_contract(self, contract_factory):
+        erc1155, owner, _, _ = contract_factory
+
+        recipient = erc1155.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mint',
+                [recipient, *TOKEN_ID, *MINT_VALUE, DATA]),
+            "ERC1155: transfer to non-ERC1155Receiver implementer")
+
+    #
+    # Burning
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_burn(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        subject = account.contract_address
+
+        await signer.send_transaction(
+            account, erc1155.contract_address, 'burn',
+            [subject, *TOKEN_ID, *BURN_value])
+
+        execution_info = await erc1155.balanceOf(subject, TOKEN_ID).execute()
+        assert execution_info.result.balance == sub_uint(MINT_VALUE, BURN_value)
+
+
+    @pytest.mark.asyncio
+    async def test_burn_emits_event(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        subject = account.contract_address
+
+        execution_info = await signer.send_transaction(
+            account, erc1155.contract_address, 'burn',
+            [subject, *TOKEN_ID, *BURN_value])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferSingle',
+            data=[
+                subject,       # operator
+                subject,       # from
+                ZERO_ADDRESS,  # to
+                *TOKEN_ID,
+                *BURN_value
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_approved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        operator = account1.contract_address
+        subject = account2.contract_address
+
+        # account2 approves account
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        await signer.send_transaction(
+            account1, erc1155.contract_address, 'burn',
+            [subject, *TOKEN_ID, *BURN_value])
+
+        execution_info = await erc1155.balanceOf(subject, TOKEN_ID).execute()
+        assert execution_info.result.balance == sub_uint(MINT_VALUE, BURN_value)
+
+
+    @pytest.mark.asyncio
+    async def test_burn_approved_emits_event(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        operator = account1.contract_address
+        subject = account2.contract_address
+
+        # account2 approves account
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE]
+        )
+
+        execution_info = await signer.send_transaction(
+            account1, erc1155.contract_address, 'burn',
+            [subject, *TOKEN_ID, *BURN_value]
+        )
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferSingle',
+            data=[
+                operator,      # operator
+                subject,       # from
+                ZERO_ADDRESS,  # to
+                *TOKEN_ID,
+                *BURN_value
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_insufficient_balance(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        subject = account.contract_address
+        burn_value = add_uint(MINT_VALUE, to_uint(1))
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burn',
+                [subject, *TOKEN_ID, *burn_value]),
+            "ERC1155: burn value exceeds balance")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_invalid_value(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        burner = account.contract_address
+
+        # mint max possible to avoid insufficient balance
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mint',
+            [burner, *TOKEN_ID, *MAX_UINT256, DATA])
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burn',
+                [burner, *TOKEN_ID, *INVALID_UINT256]),
+            "ERC1155: value is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_invalid_id(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burn',
+                [burner, *INVALID_UINT256, *to_uint(0)]),
+            "ERC1155: token_id is not a valid Uint256")
+
+
+    #
+    # Batch Minting
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MINT_VALUES), DATA])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [recipient]*3, TOKEN_IDS).execute()
+        assert execution_info.result.balances == MINT_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_emits_event(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        execution_info = await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MINT_VALUES), DATA])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferBatch',
+            data=[
+                owner.contract_address,  # operator
+                ZERO_ADDRESS,            # from
+                recipient,               # to
+                *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(MINT_VALUES),
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_to_zero_address(self, contract_factory):
+        erc1155, owner, _, _ = contract_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mintBatch',
+                [ZERO_ADDRESS, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MINT_VALUES), DATA]),
+            "ERC1155: mint to the zero address")
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_overflow(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        # Bring recipient's balance to max possible
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MAX_UINT_VALUES), DATA])
+
+        # Issuing recipient any more on just 1 token_id
+        # should revert due to overflow
+        values = to_uint_array([0, 1, 0])
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mintBatch',
+                [recipient, *prepare_calldata(TOKEN_IDS), *prepare_calldata(values), DATA]),
+            "ERC1155: balance overflow")
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "values,token_ids,error",
+        [
+            (INVALID_VALUES, TOKEN_IDS, "ERC1155: value is not a valid Uint256"),
+            (MINT_VALUES, INVALID_IDS, "ERC1155: token_id is not a valid Uint256")
+        ])
+    async def test_mint_batch_invalid_uint(self, contract_factory, values, token_ids, error):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mintBatch',
+                [recipient, *prepare_calldata(token_ids), *prepare_calldata(values), DATA]),
+            error)
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "values,token_ids",
+        [
+            (MINT_VALUES[:2], TOKEN_IDS),
+            (MINT_VALUES, TOKEN_IDS[:2])
+        ])
+    async def test_mint_batch_uneven_arrays(self, contract_factory, values, token_ids):
+        erc1155, owner, account, _ = contract_factory
+
+        recipient = account.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                owner, erc1155.contract_address, 'mintBatch',
+                [recipient, *prepare_calldata(token_ids), *prepare_calldata(values), DATA]),
+            "ERC1155: ids and values length mismatch")
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_to_receiver(self, contract_factory):
+        erc1155, owner, _, receiver = contract_factory
+
+        recipient = receiver.contract_address
+
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [
+                recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(MINT_VALUES), DATA
+            ])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [recipient]*3, TOKEN_IDS).execute()
+        assert execution_info.result.balances == MINT_VALUES
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_to_receiver_rejection(self, contract_factory):
+        erc1155, owner, _, receiver = contract_factory
+
+        recipient = receiver.contract_address
+
+        await assert_revert(signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [
+                recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(MINT_VALUES), *REJECT_DATA
+            ]),
+            "ERC1155: ERC1155Receiver rejected tokens")
+
+
+    @pytest.mark.asyncio
+    async def test_mint_batch_to_non_receiver(self, contract_factory):
+        erc1155, owner, _, _ = contract_factory
+
+        recipient = erc1155.contract_address
+
+        await assert_revert(signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [
+                recipient, *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(MINT_VALUES), DATA
+            ]),
+            "ERC1155: transfer to non-ERC1155Receiver implementer")
+
+    #
+    # Batch Burning
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+
+        await signer.send_transaction(
+            account, erc1155.contract_address, 'burnBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(BURN_VALUES)])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [burner]*3, TOKEN_IDS).execute()
+        assert execution_info.result.balances == BURN_DIFFERENCES
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_emits_event(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+
+        execution_info = await signer.send_transaction(
+            account, erc1155.contract_address, 'burnBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(BURN_VALUES)])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferBatch',
+            data=[
+                burner,        # operator
+                burner,        # from
+                ZERO_ADDRESS,  # to
+                *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(BURN_VALUES),
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_from_approved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        burner = account2.contract_address
+        operator = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        await signer.send_transaction(
+            account1, erc1155.contract_address, 'burnBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(BURN_VALUES)])
+
+        execution_info = await erc1155.balanceOfBatch(
+            [burner]*3, TOKEN_IDS).execute()
+        assert execution_info.result.balances == BURN_DIFFERENCES
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_from_approved_emits_event(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        burner = account2.contract_address
+        operator = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, TRUE])
+
+        execution_info = await signer.send_transaction(
+            account1, erc1155.contract_address, 'burnBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(BURN_VALUES)])
+
+        assert_event_emitted(
+            execution_info,
+            from_address=erc1155.contract_address,
+            name='TransferBatch',
+            data=[
+                operator,      # operator
+                burner,        # from
+                ZERO_ADDRESS,  # to
+                *prepare_calldata(TOKEN_IDS),
+                *prepare_calldata(BURN_VALUES),
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_from_unapproved(self, minted_factory):
+        erc1155, account1, account2, _ = minted_factory
+
+        burner = account2.contract_address
+        operator = account1.contract_address
+
+        await signer.send_transaction(
+            account2, erc1155.contract_address, 'setApprovalForAll',
+            [operator, FALSE])
+
+        await assert_revert(signer.send_transaction(
+            account1, erc1155.contract_address, 'burnBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(BURN_VALUES)]),
+            "ERC1155: caller is not owner nor approved")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_from_zero_address(self, minted_factory):
+        erc1155, _, _, _ = minted_factory
+
+        values = [to_uint(0)]*3
+
+        # Attempt to burn nothing (since cannot mint non_zero balance to burn)
+        # note invoking this way (without signer) gives caller address of 0
+        await assert_revert(
+            erc1155.burnBatch(ZERO_ADDRESS, TOKEN_IDS, values).execute(),
+            "ERC1155: burn from the zero address")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_insufficent_balance(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+        values = MINT_VALUES.copy()
+        values[1] = add_uint(values[1], to_uint(1))
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burnBatch',
+                [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(values)]),
+            "ERC1155: burn value exceeds balance")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_invalid_value(self, contract_factory):
+        erc1155, owner, account, _ = contract_factory
+
+        burner = account.contract_address
+
+        # mint max possible to avoid insufficient balance
+        await signer.send_transaction(
+            owner, erc1155.contract_address, 'mintBatch',
+            [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(MAX_UINT_VALUES), 0])
+
+        # attempt passing an invalid uint in batch
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burnBatch',
+                [burner, *prepare_calldata(TOKEN_IDS), *prepare_calldata(INVALID_VALUES)]),
+            "ERC1155: value is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    async def test_burn_batch_invalid_id(self, minted_factory):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+        burn_values = [to_uint(0)]*3
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burnBatch',
+                [burner, *prepare_calldata(INVALID_IDS), *prepare_calldata(burn_values)]),
+            "ERC1155: token_id is not a valid Uint256")
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "values,token_ids",
+        [
+            (BURN_VALUES[:2], TOKEN_IDS),
+            (BURN_VALUES, TOKEN_IDS[:2])
+        ]
+    )
+    async def test_burn_batch_uneven_arrays(self, 
+            minted_factory, values, token_ids):
+        erc1155, _, account, _ = minted_factory
+
+        burner = account.contract_address
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc1155.contract_address, 'burnBatch',
+                [burner, *prepare_calldata(token_ids), *prepare_calldata(values)]),
+            "ERC1155: ids and values length mismatch")

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/ERC20BaseSuite.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/ERC20BaseSuite.py
@@ -1,0 +1,714 @@
+import pytest
+
+from signers import MockSigner
+from nile.utils import (
+    to_uint, add_uint, sub_uint, str_to_felt, MAX_UINT256, ZERO_ADDRESS,
+    INVALID_UINT256, TRUE, assert_revert
+)
+from utils import (
+    assert_event_emitted, assert_events_emitted, contract_path, State, get_cairo_path
+)
+
+
+signer = MockSigner(123456789987654321)
+
+# testing vars
+NAME = str_to_felt("Token")
+SYMBOL = str_to_felt("TKN")
+DECIMALS = 18
+RECIPIENT = 123
+INIT_SUPPLY = to_uint(1000)
+AMOUNT = to_uint(200)
+UINT_ONE = to_uint(1)
+UINT_ZERO = to_uint(0)
+
+
+
+class ERC20Base:
+    #
+    # Constructor
+    #
+
+    @pytest.mark.asyncio
+    async def test_constructor(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        # balanceOf recipient
+        execution_info = await erc20.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == INIT_SUPPLY
+
+        # totalSupply
+        execution_info = await erc20.totalSupply().execute()
+        assert execution_info.result.totalSupply == INIT_SUPPLY
+
+
+    @pytest.mark.asyncio
+    async def test_constructor_exceed_max_decimals(self, contract_factory):
+        _, account, _ = contract_factory
+
+        bad_decimals = 2**8 + 1
+
+        starknet = await State.init()
+        await assert_revert(
+            starknet.deploy(
+                contract_path("openzeppelin/token/erc20/presets/ERC20.cairo"),
+                constructor_calldata=[
+                    NAME,
+                    SYMBOL,
+                    bad_decimals,
+                    *INIT_SUPPLY,
+                    account.contract_address
+                ],
+                cairo_path=get_cairo_path()
+            ),
+            reverted_with="ERC20: decimals exceed 2^8"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_name(self, contract_factory):
+        erc20, _, _ = contract_factory
+        execution_info = await erc20.name().execute()
+        assert execution_info.result.name == NAME
+
+
+    @pytest.mark.asyncio
+    async def test_symbol(self, contract_factory):
+        erc20, _, _ = contract_factory
+        execution_info = await erc20.symbol().execute()
+        assert execution_info.result.symbol == SYMBOL
+
+
+    @pytest.mark.asyncio
+    async def test_decimals(self, contract_factory):
+        erc20, _, _ = contract_factory
+        execution_info = await erc20.decimals().execute()
+        assert execution_info.result.decimals == DECIMALS
+
+
+    #
+    # approve
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_approve(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # check spender's allowance starts at zero
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == UINT_ZERO
+
+        # set approval
+        return_bool = await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        # check spender's allowance
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == AMOUNT
+
+
+
+    @pytest.mark.asyncio
+    async def test_approve_emits_event(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Approval',
+            data=[
+                account.contract_address,
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_from_zero_address(self, contract_factory):
+        erc20, _, spender = contract_factory
+
+        # Without using an account abstraction, the caller address
+        # (get_caller_address) is zero
+        await assert_revert(
+            erc20.approve(spender.contract_address, AMOUNT).execute(),
+            reverted_with="ERC20: cannot approve from the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_to_zero_address(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                ZERO_ADDRESS,
+                *UINT_ONE
+            ]),
+            reverted_with="ERC20: cannot approve to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_invalid_uint256(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc20.contract_address, 'approve', [
+                    spender.contract_address,
+                    *INVALID_UINT256
+                ]),
+            reverted_with="ERC20: amount is not a valid Uint256"
+        )
+
+
+    #
+    # transfer
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_transfer(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        # check original totalSupply
+        execution_info = await erc20.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == INIT_SUPPLY
+
+        # check recipient original balance
+        execution_info = await erc20.balanceOf(RECIPIENT).execute()
+        assert execution_info.result.balance == UINT_ZERO
+
+        # transfer
+        return_bool = await signer.send_transaction(
+            account, erc20.contract_address, 'transfer', [
+                RECIPIENT,
+                *AMOUNT
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        # check account balance
+        execution_info = await erc20.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == sub_uint(INIT_SUPPLY, AMOUNT)
+
+        # check recipient balance
+        execution_info = await erc20.balanceOf(RECIPIENT).execute()
+        assert execution_info.result.balance == AMOUNT
+
+        # check totalSupply
+        execution_info = await erc20.totalSupply().execute()
+        assert execution_info.result.totalSupply == INIT_SUPPLY
+
+
+    @pytest.mark.asyncio
+    async def test_transfer_emits_event(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'transfer', [
+                RECIPIENT,
+                *AMOUNT
+            ])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Transfer',
+            data=[
+                account.contract_address,
+                RECIPIENT,
+                *AMOUNT
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transfer_not_enough_balance(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'transfer', [
+                RECIPIENT,
+                *add_uint(INIT_SUPPLY, UINT_ONE)
+            ]),
+            reverted_with="ERC20: transfer amount exceeds balance"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transfer_to_zero_address(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'transfer', [
+                ZERO_ADDRESS,
+                *UINT_ONE
+            ]),
+            reverted_with="ERC20: cannot transfer to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transfer_from_zero_address(self, contract_factory):
+        erc20, _, _ = contract_factory
+
+        # Without using an account abstraction, the caller address
+        # (get_caller_address) is zero
+        await assert_revert(
+            erc20.transfer(RECIPIENT, UINT_ONE).execute(),
+            reverted_with="ERC20: cannot transfer from the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transfer_invalid_uint256(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'transfer', [
+                RECIPIENT,
+                *INVALID_UINT256
+            ]),
+            reverted_with="ERC20: amount is not a valid Uint256"
+        )
+
+
+    #
+    # transferFrom
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+        # transferFrom
+        return_bool = await signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *AMOUNT
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        # check account balance
+        execution_info = await erc20.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == sub_uint(INIT_SUPPLY, AMOUNT)
+
+        # check recipient balance
+        execution_info = await erc20.balanceOf(RECIPIENT).execute()
+        assert execution_info.result.balance == AMOUNT
+
+        # check spender allowance after tx
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == UINT_ZERO
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_emits_event(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ])
+
+        # transferFrom
+        tx_exec_info = await signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *AMOUNT
+            ])
+
+        # check events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc20.contract_address, 'Approval', [
+                    account.contract_address, spender.contract_address, *UINT_ZERO]],
+                [1, erc20.contract_address, 'Transfer', [
+                        account.contract_address, RECIPIENT, *AMOUNT]]
+            ]
+        )
+
+
+    async def test_transferFrom_doesnt_consume_infinite_allowance(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # approve
+        await signer.send_transaction(account, erc20.contract_address, 'approve', [spender.contract_address, *MAX_UINT256])
+
+        # check approval
+        execution_info_1 = await erc20.allowance(account.contract_address, spender.contract_address).call()
+        assert execution_info_1.result.remaining == MAX_UINT256
+
+        # transferFrom
+        await signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *AMOUNT
+            ])
+
+        # re-check approval
+        execution_info_2 = await erc20.allowance(account.contract_address, spender.contract_address).call()
+        assert execution_info_2.result.remaining == MAX_UINT256
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_greater_than_allowance(self, contract_factory):
+        erc20, account, spender = contract_factory
+        # we use the same signer to control the main and the spender accounts
+        # this is ok since they're still two different accounts
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        fail_amount = add_uint(AMOUNT, UINT_ONE)
+
+        # increasing the transfer amount above allowance
+        await assert_revert(signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *fail_amount
+            ]),
+            reverted_with="ERC20: insufficient allowance"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_from_zero_address(self, contract_factory):
+        erc20, _, spender = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                ZERO_ADDRESS,
+                RECIPIENT,
+                *AMOUNT
+            ]),
+            reverted_with="ERC20: insufficient allowance"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_to_zero_address(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *UINT_ONE
+            ]
+        )
+
+        await assert_revert(signer.send_transaction(
+            spender, erc20.contract_address, 'transferFrom', [
+                account.contract_address,
+                ZERO_ADDRESS,
+                *UINT_ONE
+            ]),
+            reverted_with="ERC20: cannot transfer to the zero address"
+        )
+
+
+    #
+    # increaseAllowance
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_increaseAllowance(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == UINT_ZERO
+
+        # set approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        # check allowance
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == AMOUNT
+
+        # increase allowance
+        return_bool = await signer.send_transaction(
+            account, erc20.contract_address, 'increaseAllowance', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        # check spender's allowance increased
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == add_uint(AMOUNT, AMOUNT)
+
+
+    @pytest.mark.asyncio
+    async def test_increaseAllowance_emits_event(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # set approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ])
+
+        # increase allowance
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'increaseAllowance', [
+                spender.contract_address,
+                *AMOUNT
+            ])
+
+        new_allowance = add_uint(AMOUNT, AMOUNT)
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Approval',
+            data=[
+                account.contract_address,
+                spender.contract_address,
+                *new_allowance
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_increaseAllowance_overflow(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # approve max
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *MAX_UINT256
+            ]
+        )
+
+        # overflow_amount adds (1, 0) to (2**128 - 1, 2**128 - 1)
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'increaseAllowance', [
+                spender.contract_address,
+                *UINT_ONE
+            ]),
+            reverted_with="ERC20: allowance overflow"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_increaseAllowance_to_zero_address(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'increaseAllowance', [
+                ZERO_ADDRESS,
+                *AMOUNT
+            ])
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_increaseAllowance_from_zero_address(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        await assert_revert(
+            erc20.increaseAllowance(RECIPIENT, AMOUNT).execute()
+        )
+
+
+    #
+    # decreaseAllowance
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == UINT_ZERO
+
+        # set approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == AMOUNT
+
+        # decrease allowance
+        return_bool = await signer.send_transaction(
+            account, erc20.contract_address, 'decreaseAllowance', [
+                spender.contract_address,
+                *UINT_ONE
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        new_allowance = sub_uint(AMOUNT, UINT_ONE)
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == new_allowance
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance_emits_event(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        # set approve
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *INIT_SUPPLY
+            ])
+
+        # decrease allowance
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'decreaseAllowance', [
+                spender.contract_address,
+                *AMOUNT
+            ])
+
+        new_allowance = sub_uint(INIT_SUPPLY, AMOUNT)
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Approval',
+            data=[
+                account.contract_address,
+                spender.contract_address,
+                *new_allowance
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance_overflow(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        execution_info = await erc20.allowance(account.contract_address, spender.contract_address).execute()
+        assert execution_info.result.remaining == AMOUNT
+
+        allowance_plus_one = add_uint(AMOUNT, UINT_ONE)
+
+        # increasing the decreased allowance amount by more than the spender's allowance
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'decreaseAllowance', [
+                spender.contract_address,
+                *allowance_plus_one
+            ]),
+            reverted_with="ERC20: allowance below zero"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance_to_zero_address(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'decreaseAllowance', [
+                ZERO_ADDRESS,
+                *AMOUNT
+            ])
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance_from_zero_address(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'approve', [
+                spender.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        await assert_revert(
+            erc20.decreaseAllowance(RECIPIENT, AMOUNT).execute()
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_decreaseAllowance_invalid_uint256(self, contract_factory):
+        erc20, account, spender = contract_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc20.contract_address, 'decreaseAllowance', [
+                    spender.contract_address,
+                    *INVALID_UINT256
+                ]),
+            reverted_with="ERC20: subtracted_value is not a valid Uint256"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20.py
@@ -1,0 +1,54 @@
+import pytest
+from signers import MockSigner
+from utils import get_contract_class, cached_contract, State, Account
+from ERC20BaseSuite import ERC20Base, NAME, SYMBOL, DECIMALS, INIT_SUPPLY
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc20_cls = get_contract_class('ERC20')
+
+    return account_cls, erc20_cls
+
+
+@pytest.fixture(scope='module')
+async def erc20_init(contract_classes):
+    account_cls, erc20_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc20 = await starknet.deploy(
+        contract_class=erc20_cls,
+        constructor_calldata=[
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            account1.contract_address,        # recipient
+        ]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc20
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc20_init):
+    account_cls, erc20_cls = contract_classes
+    state, account1, account2, erc20 = erc20_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc20 = cached_contract(_state, erc20_cls, erc20)
+    return erc20, account1, account2
+
+
+class TestERC20(ERC20Base):
+    pass

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Burnable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Burnable.py
@@ -1,0 +1,216 @@
+import pytest
+from signers import MockSigner
+from nile.utils import (
+    add_uint, sub_uint, ZERO_ADDRESS, INVALID_UINT256, assert_revert,
+)
+from utils import (
+    get_contract_class, cached_contract, assert_events_emitted,
+    assert_event_emitted, State, Account
+)
+from ERC20BaseSuite import (
+    ERC20Base, NAME, SYMBOL, DECIMALS, INIT_SUPPLY, AMOUNT, UINT_ONE, UINT_ZERO
+)
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc20_cls = get_contract_class('ERC20Burnable')
+
+    return account_cls, erc20_cls
+
+
+@pytest.fixture(scope='module')
+async def erc20_init(contract_classes):
+    _, erc20_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc20 = await starknet.deploy(
+        contract_class=erc20_cls,
+        constructor_calldata=[
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            account1.contract_address,        # recipient
+        ]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc20
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc20_init):
+    account_cls, erc20_cls = contract_classes
+    state, account1, account2, erc20 = erc20_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc20 = cached_contract(_state, erc20_cls, erc20)
+
+    return erc20, account1, account2
+
+
+class TestERC20Burnable(ERC20Base):
+    #
+    # burn
+    #
+
+    @pytest.mark.asyncio
+    async def test_burn(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'burn', [
+                *AMOUNT
+            ])
+
+        new_balance = sub_uint(INIT_SUPPLY, AMOUNT)
+
+        execution_info = await erc20.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == new_balance
+
+
+    @pytest.mark.asyncio
+    async def test_burn_emits_event(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'burn', [
+                *AMOUNT
+            ])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Transfer',
+            data=[
+                account.contract_address,
+                ZERO_ADDRESS,
+                *AMOUNT
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_not_enough_balance(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        balance_plus_one = add_uint(INIT_SUPPLY, UINT_ONE)
+
+        await assert_revert(signer.send_transaction(
+            account, erc20.contract_address, 'burn', [
+                *balance_plus_one
+            ]),
+            reverted_with="ERC20: burn amount exceeds balance"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_zero_address(self, contract_factory):
+        erc20, _, _ = contract_factory
+
+        await assert_revert(
+            erc20.burn(UINT_ONE).execute(),
+            reverted_with="ERC20: cannot burn from the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_invalid_uint256(self, contract_factory):
+        erc20, _, _ = contract_factory
+
+        await assert_revert(
+            erc20.burn(INVALID_UINT256).execute(),
+            reverted_with="ERC20: amount is not a valid Uint256"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from(self, contract_factory):
+        erc20, account1, account2 = contract_factory
+
+        await signer.send_transaction(
+            account1, erc20.contract_address, 'increaseAllowance', [
+                account2.contract_address,
+                *AMOUNT
+            ])
+
+        await signer.send_transaction(
+            account2, erc20.contract_address, 'burnFrom', [
+                account1.contract_address,
+                *AMOUNT
+            ])
+
+        new_balance = sub_uint(INIT_SUPPLY, AMOUNT)
+
+        execution_info = await erc20.balanceOf(account1.contract_address).execute()
+        assert execution_info.result.balance == new_balance
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_emits_event(self, contract_factory):
+        erc20, account1, account2 = contract_factory
+
+        await signer.send_transaction(
+            account1, erc20.contract_address, 'increaseAllowance', [
+                account2.contract_address,
+                *AMOUNT
+            ])
+
+        tx_exec_info = await signer.send_transaction(
+            account2, erc20.contract_address, 'burnFrom', [
+                account1.contract_address,
+                *AMOUNT
+            ])
+
+        # events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc20.contract_address, 'Approval', [
+                    account1.contract_address, account2.contract_address, *UINT_ZERO]],
+                [1, erc20.contract_address, 'Transfer', [
+                    account1.contract_address, ZERO_ADDRESS, *AMOUNT]]
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_over_allowance(self, contract_factory):
+        erc20, account1, account2 = contract_factory
+
+        await signer.send_transaction(
+            account1, erc20.contract_address, 'increaseAllowance', [
+                account2.contract_address,
+                *AMOUNT
+            ])
+
+        await assert_revert(signer.send_transaction(
+            account2, erc20.contract_address, 'burnFrom', [
+                account1.contract_address,
+                *INIT_SUPPLY
+            ]),
+            reverted_with="ERC20: insufficient allowance"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_no_allowance(self, contract_factory):
+        erc20, account1, account2 = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account2, erc20.contract_address, 'burnFrom', [
+                account1.contract_address,
+                *AMOUNT
+            ]),
+            reverted_with="ERC20: insufficient allowance"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Mintable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Mintable.py
@@ -1,0 +1,152 @@
+import pytest
+from signers import MockSigner
+from nile.utils import (
+    add_uint, sub_uint, MAX_UINT256, ZERO_ADDRESS, INVALID_UINT256, assert_revert
+)
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted, State, Account
+)
+from ERC20BaseSuite import ERC20Base, NAME, SYMBOL, DECIMALS, INIT_SUPPLY, UINT_ONE
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc20_cls = get_contract_class('ERC20Mintable')
+
+    return account_cls, erc20_cls
+
+
+@pytest.fixture(scope='module')
+async def erc20_init(contract_classes):
+    account_cls, erc20_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc20 = await starknet.deploy(
+        contract_class=erc20_cls,
+        constructor_calldata=[
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            account1.contract_address,        # recipient
+            account1.contract_address         # owner
+        ]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc20,
+    )
+
+@pytest.fixture
+def contract_factory(contract_classes, erc20_init):
+    account_cls, erc20_cls = contract_classes
+    state, account1, account2, erc20 = erc20_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc20 = cached_contract(_state, erc20_cls, erc20)
+
+    return erc20, account1, account2
+
+
+class TestERC20Mintable(ERC20Base, OwnableBase):
+    #
+    # mint
+    #
+
+    @pytest.mark.asyncio
+    async def test_mint(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'mint', [
+                account.contract_address,
+                *UINT_ONE
+            ])
+
+        # check new supply
+        execution_info = await erc20.totalSupply().execute()
+        new_supply = execution_info.result.totalSupply
+        assert new_supply == add_uint(INIT_SUPPLY, UINT_ONE)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_emits_event(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc20.contract_address, 'mint', [
+                account.contract_address,
+                *UINT_ONE
+            ])
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc20.contract_address,
+            name='Transfer',
+            data=[
+                ZERO_ADDRESS,
+                account.contract_address,
+                *UINT_ONE
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_zero_address(self, contract_factory):
+        erc20, account, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account,
+            erc20.contract_address,
+            'mint',
+            [ZERO_ADDRESS, *UINT_ONE]
+        ),
+            reverted_with="ERC20: cannot mint to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_overflow(self, contract_factory):
+        erc20, account, recipient = contract_factory
+        # pass_amount subtracts the already minted supply from MAX_UINT256 in order for
+        # the minted supply to equal MAX_UINT256
+        # (2**128 - 1, 2**128 - 1)
+        pass_amount = sub_uint(MAX_UINT256, INIT_SUPPLY)
+
+        await signer.send_transaction(
+            account, erc20.contract_address, 'mint', [
+                recipient.contract_address,
+                *pass_amount
+            ])
+
+        # totalSupply is MAX_UINT256 therefore adding (1, 0) should fail
+        await assert_revert(
+            signer.send_transaction(
+                account, erc20.contract_address, 'mint', [
+                    recipient.contract_address,
+                    *UINT_ONE
+                ]),
+            reverted_with="ERC20: mint overflow"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_invalid_uint256(self, contract_factory):
+        erc20, account, recipient = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account,
+            erc20.contract_address,
+            'mint',
+            [recipient.contract_address, *INVALID_UINT256]),
+            reverted_with="ERC20: amount is not a valid Uint256"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Pausable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Pausable.py
@@ -1,0 +1,194 @@
+import pytest
+from signers import MockSigner
+from nile.utils import TRUE, FALSE, assert_revert
+from utils import (
+    get_contract_class, cached_contract, State, Account
+)
+from ERC20BaseSuite import ERC20Base, NAME, SYMBOL, DECIMALS, INIT_SUPPLY, AMOUNT
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc20_cls = get_contract_class('ERC20Pausable')
+
+    return account_cls, erc20_cls
+
+
+@pytest.fixture(scope='module')
+async def erc20_init(contract_classes):
+    _, erc20_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc20 = await starknet.deploy(
+        contract_class=erc20_cls,
+        constructor_calldata=[
+            NAME,
+            SYMBOL,
+            DECIMALS,
+            *INIT_SUPPLY,
+            account1.contract_address,        # recipient
+            account1.contract_address         # owner
+        ]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc20
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc20_init):
+    account_cls, erc20_cls = contract_classes
+    state, account1, account2, erc20 = erc20_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc20 = cached_contract(_state, erc20_cls, erc20)
+
+    return erc20, account1, account2
+
+
+class TestPausable(ERC20Base, OwnableBase):
+    #
+    # pause
+    #
+
+    @pytest.mark.asyncio
+    async def test_constructor(self, contract_factory):
+        erc20, _, _ = contract_factory
+
+        execution_info = await erc20.paused().execute()
+        assert execution_info.result.paused == FALSE
+
+
+    @pytest.mark.asyncio
+    async def test_pause(self, contract_factory):
+        erc20, owner, other = contract_factory
+
+        await signer.send_transaction(owner, erc20.contract_address, 'pause', [])
+
+        execution_info = await erc20.paused().execute()
+        assert execution_info.result.paused == TRUE
+
+        await assert_revert(signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'transfer',
+            [other.contract_address, *AMOUNT]
+        ),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'transferFrom',
+            [other.contract_address, other.contract_address, *AMOUNT]
+        ),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'approve',
+            [other.contract_address, *AMOUNT]
+        ),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'increaseAllowance',
+            [other.contract_address, *AMOUNT]
+        ),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'decreaseAllowance',
+            [other.contract_address, *AMOUNT]
+        ),
+            reverted_with="Pausable: paused"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_unpause(self, contract_factory):
+        erc20, owner, other = contract_factory
+
+        await signer.send_transaction(owner, erc20.contract_address, 'pause', [])
+        await signer.send_transaction(owner, erc20.contract_address, 'unpause', [])
+
+        execution_info = await erc20.paused().execute()
+        assert execution_info.result.paused == FALSE
+
+        success = await signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'transfer',
+            [other.contract_address, *AMOUNT]
+        )
+        assert success.call_info.retdata[1] == TRUE
+
+        success = await signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'approve',
+            [other.contract_address, *AMOUNT]
+        )
+        assert success.call_info.retdata[1] == TRUE
+
+        success = await signer.send_transaction(
+            other,
+            erc20.contract_address,
+            'transferFrom',
+            [owner.contract_address, other.contract_address, *AMOUNT]
+        )
+        assert success.call_info.retdata[1] == TRUE
+
+        success = await signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'increaseAllowance',
+            [other.contract_address, *AMOUNT]
+        )
+        assert success.call_info.retdata[1] == TRUE
+
+        success = await signer.send_transaction(
+            owner,
+            erc20.contract_address,
+            'decreaseAllowance',
+            [other.contract_address, *AMOUNT]
+        )
+        assert success.call_info.retdata[1] == TRUE
+
+
+    @pytest.mark.asyncio
+    async def test_only_owner(self, contract_factory):
+        erc20, _, other = contract_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                other, erc20.contract_address, 'pause', []
+            ),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+        await assert_revert(
+            signer.send_transaction(
+                other, erc20.contract_address, 'unpause', []
+            ),
+            reverted_with="Ownable: caller is not the owner"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Upgradeable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc20/test_ERC20Upgradeable.py
@@ -1,0 +1,179 @@
+import pytest
+from starkware.starknet.public.abi import get_selector_from_name
+from signers import MockSigner
+from nile.utils import to_uint, sub_uint, str_to_felt, assert_revert, TRUE
+from utils import get_contract_class, cached_contract, State, Account
+
+
+signer = MockSigner(123456789987654321)
+
+USER = 999
+INIT_SUPPLY = to_uint(1000)
+AMOUNT = to_uint(250)
+NAME = str_to_felt('Upgradeable Token')
+SYMBOL = str_to_felt('UTKN')
+DECIMALS = 18
+
+
+class TestERC20Upgradeable:
+    @pytest.fixture(scope='module')
+    def contract_classes(self):
+        account_cls = Account.get_class
+        token_cls = get_contract_class('ERC20Upgradeable')
+        proxy_cls = get_contract_class('Proxy')
+
+        return account_cls, token_cls, proxy_cls
+
+
+    @pytest.fixture(scope='module')
+    async def token_init(self, contract_classes):
+        account_cls, token_cls, proxy_cls = contract_classes
+        starknet = await State.init()
+        account1 = await Account.deploy(signer.public_key)
+        account2 = await Account.deploy(signer.public_key)
+        token_v1 = await starknet.declare(
+            contract_class=token_cls,
+        )
+        token_v2 = await starknet.declare(
+            contract_class=token_cls,
+        )
+        selector = get_selector_from_name('initializer')
+        params = [
+            NAME,                       # name
+            SYMBOL,                     # symbol
+            DECIMALS,                   # decimals
+            *INIT_SUPPLY,               # initial supply
+            account1.contract_address,  # recipient
+            account1.contract_address   # admin
+        ]
+        proxy = await starknet.deploy(
+            contract_class=proxy_cls,
+            constructor_calldata=[
+                token_v1.class_hash,
+                selector, 
+                len(params), 
+                *params
+            ]
+        )
+        return (
+            starknet.state,
+            account1,
+            account2,
+            token_v1,
+            token_v2,
+            proxy
+        )
+
+
+    @pytest.fixture
+    def token_factory(self, contract_classes, token_init):
+        account_cls, _, proxy_cls = contract_classes
+        state, account1, account2, token_v1, token_v2, proxy = token_init
+        _state = state.copy()
+        account1 = cached_contract(_state, account_cls, account1)
+        account2 = cached_contract(_state, account_cls, account2)
+        proxy = cached_contract(_state, proxy_cls, proxy)
+
+        return account1, account2, proxy, token_v1, token_v2
+
+
+    @pytest.mark.asyncio
+    async def test_constructor(self, token_factory):
+        admin, _, proxy, *_ = token_factory
+
+        execution_info = await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'name', []),
+                (proxy.contract_address, 'symbol', []),
+                (proxy.contract_address, 'decimals', []),
+                (proxy.contract_address, 'totalSupply', [])
+            ]
+        )
+
+        # check values
+        expected = [5, NAME, SYMBOL, DECIMALS, *INIT_SUPPLY]
+        assert execution_info.call_info.retdata == expected
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade(self, token_factory):
+        admin, _, proxy, _, token_v2 = token_factory
+
+        # transfer
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'transfer', [USER, *AMOUNT]
+        )
+
+        # upgrade
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'upgrade', [token_v2.class_hash]
+        )
+
+        # fetch values
+        execution_info = await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'balanceOf', [admin.contract_address]),
+                (proxy.contract_address, 'balanceOf', [USER]),
+                (proxy.contract_address, 'totalSupply', [])
+            ]
+        )
+
+        expected = [
+            6,                                      # number of return values
+            *sub_uint(INIT_SUPPLY, AMOUNT),         # balanceOf admin
+            *AMOUNT,                                # balanceOf USER
+            *INIT_SUPPLY                            # totalSupply
+        ]
+
+        assert execution_info.call_info.retdata == expected
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade_from_nonadmin(self, token_factory):
+        admin, non_admin, proxy, _, token_v2 = token_factory
+
+        # should revert
+        await assert_revert(signer.send_transaction(
+            non_admin, proxy.contract_address, 'upgrade', [token_v2.class_hash]),
+            reverted_with="Proxy: caller is not admin"
+        )
+
+        # should upgrade from admin
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'upgrade', [token_v2.class_hash]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade_transferFrom(self, token_factory):
+        admin, non_admin, proxy, _, _ = token_factory
+
+        # approve
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'approve', [
+                non_admin.contract_address,
+                *AMOUNT
+            ]
+        )
+
+        # transferFrom
+        return_bool = await signer.send_transaction(
+            non_admin, proxy.contract_address, 'transferFrom', [
+                admin.contract_address,
+                non_admin.contract_address,
+                *AMOUNT
+            ]
+        )
+        assert return_bool.call_info.retdata[1] == TRUE
+
+        # should fail
+        await assert_revert(signer.send_transaction(
+            non_admin, proxy.contract_address, 'transferFrom', [
+                admin.contract_address,
+                non_admin.contract_address,
+                *AMOUNT
+                ]
+            )
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/ERC721BaseSuite.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/ERC721BaseSuite.py
@@ -1,0 +1,924 @@
+import pytest
+from signers import MockSigner
+from nile.utils import (
+    str_to_felt, ZERO_ADDRESS, TRUE, FALSE, assert_revert, INVALID_UINT256,
+    to_uint, sub_uint, add_uint
+)
+from utils import (
+    assert_event_emitted, assert_events_emitted,
+)
+
+
+signer = MockSigner(123456789987654321)
+
+NAME = str_to_felt("Non-fungible Token")
+SYMBOL = str_to_felt("NFT")
+NONEXISTENT_TOKEN = to_uint(999)
+# random token IDs
+TOKENS = [to_uint(5042), to_uint(793)]
+# test token
+TOKEN = TOKENS[0]
+# random user address
+RECIPIENT = 555
+# random data (mimicking bytes in Solidity)
+DATA = [0x42, 0x89, 0x55]
+# random URIs
+SAMPLE_URI_1 = str_to_felt('mock://mytoken.v1')
+SAMPLE_URI_2 = str_to_felt('mock://mytoken.v2')
+
+# selector ids
+IERC165_ID = 0x01ffc9a7
+IERC721_ID = 0x80ac58cd
+IERC721_METADATA_ID = 0x5b5e139f
+INVALID_ID = 0xffffffff
+UNSUPPORTED_ID = 0xabcd1234
+
+
+class ERC721Base:
+    #
+    # constructor
+    #
+
+    @pytest.mark.asyncio
+    async def test_constructor(self, contract_factory):
+        erc721, _, _, _, _ = contract_factory
+        execution_info = await erc721.name().execute()
+        assert execution_info.result == (NAME,)
+
+        execution_info = await erc721.symbol().execute()
+        assert execution_info.result == (SYMBOL,)
+    #
+    # supportsInterface
+    #
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('interface_id, result', [
+        [IERC165_ID, TRUE],
+        [IERC721_ID, TRUE],
+        [IERC721_METADATA_ID, TRUE],
+        [INVALID_ID, FALSE],
+        [UNSUPPORTED_ID, FALSE],
+    ])
+    async def test_supportsInterface(self, contract_factory, interface_id, result):
+        erc721, _, _, _, _ = contract_factory
+
+        execution_info = await erc721.supportsInterface(interface_id).execute()
+        assert execution_info.result == (result,)
+
+
+    #
+    # balanceOf
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_balanceOf(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint tokens to account
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'mint', [
+                    account.contract_address, *token]
+            )
+
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        n_tokens = len(TOKENS)
+        assert execution_info.result == (to_uint(n_tokens),)
+
+        # user should have zero tokens
+        execution_info = await erc721.balanceOf(RECIPIENT).execute()
+        assert execution_info.result == (to_uint(0),)
+
+
+    @pytest.mark.asyncio
+    async def test_balanceOf_zero_address(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint tokens to account
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *TOKEN]
+        )
+
+        # should revert when querying zero address
+        await assert_revert(
+            erc721.balanceOf(ZERO_ADDRESS).execute(),
+            reverted_with="ERC721: balance query for the zero address"
+        )
+
+
+    #
+    # ownerOf
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_ownerOf(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint tokens to account
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'mint', [
+                    account.contract_address, *token]
+            )
+
+            # should return account's address
+            execution_info = await erc721.ownerOf(token).execute()
+            assert execution_info.result == (account.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_ownerOf_nonexistent_token(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint token to account
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *TOKEN]
+        )
+
+        # should revert when querying nonexistent token
+        await assert_revert(
+            erc721.ownerOf(NONEXISTENT_TOKEN).execute(),
+            reverted_with="ERC721: owner query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_ownerOf_invalid_uint256(self, contract_factory):
+        erc721, _, _, _, _ = contract_factory
+
+        # should revert when querying nonexistent token
+        await assert_revert(
+            erc721.ownerOf(INVALID_UINT256).execute(),
+            reverted_with="ERC721: token_id is not a valid Uint256"
+        )
+
+
+    #
+    # approve
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_approve(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address, *TOKEN]
+        )
+
+        execution_info = await erc721.getApproved(TOKEN).execute()
+        assert execution_info.result == (spender.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_approve_emits_event(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address,
+                *TOKEN
+            ]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='Approval',
+            data=[
+                account.contract_address,
+                spender.contract_address,
+                *TOKEN
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_on_setApprovalForAll(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # set approval_for_all from account to spender
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        # approve spender to spend account's token to recipient
+        await signer.send_transaction(
+            spender, erc721.contract_address, 'approve', [
+                RECIPIENT, *TOKEN]
+        )
+
+        execution_info = await erc721.getApproved(TOKEN).execute()
+        assert execution_info.result == (RECIPIENT,)
+
+
+    @pytest.mark.asyncio
+    async def test_approve_from_zero_address(self, erc721_minted):
+        erc721, _, spender, *_ = erc721_minted
+
+        # Without using an account abstraction, the caller address
+        # (get_caller_address) is zero
+        await assert_revert(
+            erc721.approve(
+                spender.contract_address, TOKEN).execute(),
+            reverted_with="ERC721: cannot approve from the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_owner_is_recipient(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # should fail when owner is the same as address-to-be-approved
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'approve', [
+                    account.contract_address,
+                    *TOKEN
+                ]),
+            reverted_with="ERC721: approval to current owner"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_not_owner_or_operator(self, contract_factory):
+        erc721, account, spender, _, _ = contract_factory
+
+        # mint to recipient — NOT account
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                RECIPIENT, *TOKEN]
+        )
+
+        # 'approve' should fail since recipient owns token
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address,
+                *TOKEN
+            ]),
+            reverted_with="ERC721: approve caller is not owner nor approved for all"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_approve_on_already_approved(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # first approval
+        await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address, *TOKEN]
+        )
+
+        # repeat approval
+        await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address, *TOKEN]
+        )
+
+        # check that approval does not change
+        execution_info = await erc721.getApproved(TOKEN).execute()
+        assert execution_info.result == (spender.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_getApproved_nonexistent_token(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.getApproved(NONEXISTENT_TOKEN).execute(),
+            reverted_with="ERC721: approved query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_getApproved_invalid_uint256(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.getApproved(INVALID_UINT256).execute(),
+            reverted_with="ERC721: token_id is not a valid Uint256"
+        )
+
+
+    #
+    # setApprovalForAll
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        execution_info = await erc721.isApprovedForAll(
+            account.contract_address, spender.contract_address).execute()
+        assert execution_info.result == (TRUE,)
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_emits_event(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='ApprovalForAll',
+            data=[
+                account.contract_address,
+                spender.contract_address,
+                TRUE
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_when_operator_was_set_as_not_approved(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, FALSE]
+        )
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        execution_info = await erc721.isApprovedForAll(
+            account.contract_address, spender.contract_address).execute()
+        assert execution_info.result == (TRUE,)
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_with_invalid_bool_arg(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        not_bool = 2
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'setApprovalForAll', [
+                    spender.contract_address,
+                    not_bool
+                ]),
+            reverted_with="ERC721: approved is not a Cairo boolean")
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_owner_is_operator(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'setApprovalForAll', [
+                    account.contract_address,
+                    TRUE
+                ]),
+            reverted_with="ERC721: approve to caller"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_from_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.setApprovalForAll(account.contract_address, TRUE).execute(),
+            reverted_with="ERC721: either the caller or operator is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_setApprovalForAll_operator_is_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'setApprovalForAll', [
+                    ZERO_ADDRESS,
+                    TRUE
+                ]),
+            reverted_with="ERC721: either the caller or operator is the zero address"
+        )
+
+
+    #
+    # transferFrom
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_owner(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # get account's previous balance
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        previous_balance = execution_info.result.balance
+
+        # transfers token from account to recipient
+        await signer.send_transaction(
+            account, erc721.contract_address, 'transferFrom', [
+                account.contract_address, RECIPIENT, *TOKEN]
+        )
+
+        # checks recipient balance
+        execution_info = await erc721.balanceOf(RECIPIENT).execute()
+        assert execution_info.result == (to_uint(1),)
+
+        # checks account balance
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == sub_uint(
+            previous_balance, to_uint(1))
+
+        # checks token has new owner
+        execution_info = await erc721.ownerOf(TOKEN).execute()
+        assert execution_info.result == (RECIPIENT,)
+
+        # checks approval is cleared for token_id
+        execution_info = await erc721.getApproved(TOKEN).execute()
+        assert execution_info.result == (0,)
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_emits_events(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # setApprovalForAll
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        # spender transfers token from account to recipient
+        tx_exec_info = await signer.send_transaction(
+            spender, erc721.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *TOKEN
+            ]
+        )
+
+        # events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc721.contract_address, 'Approval', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]],
+                [1, erc721.contract_address, 'Transfer', [
+                    account.contract_address, RECIPIENT, *TOKEN]]
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_approved_user(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # approve spender
+        await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address, *TOKEN]
+        )
+
+        # spender transfers token from account to recipient
+        await signer.send_transaction(
+            spender, erc721.contract_address, 'transferFrom', [
+                account.contract_address, RECIPIENT, *TOKEN]
+        )
+
+        # checks user balance
+        execution_info = await erc721.balanceOf(RECIPIENT).execute()
+        assert execution_info.result == (to_uint(1),)
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_operator(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # setApprovalForAll
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        # spender transfers token from account to recipient
+        await signer.send_transaction(
+            spender, erc721.contract_address, 'transferFrom', [
+                account.contract_address, RECIPIENT, *TOKEN]
+        )
+
+        # checks user balance
+        execution_info = await erc721.balanceOf(RECIPIENT).execute()
+        assert execution_info.result == (to_uint(1),)
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_when_not_approved_or_owner(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # setApprovalForAll to false
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, FALSE]
+        )
+
+        # should be rejected when not approved
+        await assert_revert(signer.send_transaction(
+            spender, erc721.contract_address, 'transferFrom', [
+                account.contract_address,
+                RECIPIENT,
+                *TOKEN
+            ]),
+            reverted_with="ERC721: either is not approved or the caller is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_to_zero_address(self, erc721_minted):
+        erc721, account, spender, *_ = erc721_minted
+
+        # setApprovalForAll
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        try:
+            # erc721
+            await assert_revert(signer.send_transaction(
+                spender, erc721.contract_address, 'transferFrom', [
+                    account.contract_address,
+                    ZERO_ADDRESS,
+                    *TOKEN
+                ]),
+                reverted_with="ERC721: cannot transfer to the zero address"
+            )
+        except AssertionError:
+            # erc721 enumerable
+            await assert_revert(signer.send_transaction(
+                spender, erc721.contract_address, 'transferFrom', [
+                    account.contract_address,
+                    ZERO_ADDRESS,
+                    *TOKEN
+                ]),
+                reverted_with="ERC721: balance query for the zero address"
+            )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_invalid_uint256(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'transferFrom', [
+                    account.contract_address,
+                    RECIPIENT,
+                    *INVALID_UINT256
+                ]),
+            reverted_with="ERC721: token_id is not a valid Uint256"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_transferFrom_from_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # caller address is `0` when not using an account contract
+        await assert_revert(
+            erc721.transferFrom(
+                account.contract_address,
+                RECIPIENT,
+                TOKEN
+            ).execute(),
+            reverted_with="ERC721: either is not approved or the caller is the zero address"
+        )
+
+
+    #
+    # safeTransferFrom
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom(self, erc721_minted):
+        erc721, account, _, erc721_holder, _ = erc721_minted
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # check balance
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).execute()
+        assert execution_info.result == (to_uint(1),)
+
+        # check owner
+        execution_info = await erc721.ownerOf(TOKEN).execute()
+        assert execution_info.result == (erc721_holder.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_emits_events(self, erc721_minted):
+        erc721, account, _, erc721_holder, _ = erc721_minted
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+
+        # events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc721.contract_address, 'Approval', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]],
+                [1, erc721.contract_address, 'Transfer', [
+                    account.contract_address, erc721_holder.contract_address, *TOKEN]]
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_from_approved(self, erc721_minted):
+        erc721, account, spender, erc721_holder, _ = erc721_minted
+
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).execute()
+        previous_balance = execution_info.result.balance
+
+        # approve spender
+        await signer.send_transaction(
+            account, erc721.contract_address, 'approve', [
+                spender.contract_address, *TOKEN]
+        )
+
+        # spender transfers token from account to erc721_holder
+        await signer.send_transaction(
+            spender, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # erc721_holder balance check
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).execute()
+        assert execution_info.result.balance == add_uint(
+            previous_balance, to_uint(1)
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_from_operator(self, erc721_minted):
+        erc721, account, spender, erc721_holder, _ = erc721_minted
+
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).execute()
+        previous_balance = execution_info.result.balance
+
+        # setApprovalForAll
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setApprovalForAll', [
+                spender.contract_address, TRUE]
+        )
+
+        # spender transfers token from account to erc721_holder
+        await signer.send_transaction(
+            spender, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # erc721_holder balance check
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).execute()
+        assert execution_info.result.balance == add_uint(
+            previous_balance, to_uint(1)
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_when_not_approved_or_owner(self, erc721_minted):
+        erc721, account, spender, erc721_holder, _ = erc721_minted
+
+        # should fail when not approved or owner
+        await assert_revert(signer.send_transaction(
+            spender, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]),
+            reverted_with="ERC721: either is not approved or the caller is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_to_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # to zero address should be rejected
+        try:
+            await assert_revert(signer.send_transaction(
+                account, erc721.contract_address, 'safeTransferFrom', [
+                    account.contract_address,
+                    ZERO_ADDRESS,
+                    *TOKEN,
+                    len(DATA),
+                    *DATA
+                ]),
+                reverted_with="ERC721: cannot transfer to the zero address"
+            )
+        except AssertionError:
+            await assert_revert(signer.send_transaction(
+                account, erc721.contract_address, 'safeTransferFrom', [
+                    account.contract_address,
+                    ZERO_ADDRESS,
+                    *TOKEN,
+                    len(DATA),
+                    *DATA
+                ]),
+                reverted_with="ERC721: balance query for the zero address"
+            )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_from_zero_address(self, erc721_minted):
+        erc721, account, _, erc721_holder, _ = erc721_minted
+
+        # caller address is `0` when not using an account contract
+        await assert_revert(
+            erc721.safeTransferFrom(
+                account.contract_address,
+                erc721_holder.contract_address,
+                TOKEN,
+                DATA
+            ).execute(),
+            reverted_with="ERC721: either is not approved or the caller is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_to_unsupported_contract(self, erc721_minted):
+        erc721, account, _, _, unsupported = erc721_minted
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'safeTransferFrom', [
+                    account.contract_address,
+                    unsupported.contract_address,
+                    *TOKEN,
+                    len(DATA),
+                    *DATA,
+                ])
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_to_account(self, erc721_minted):
+        erc721, account, account2, *_ = erc721_minted
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'safeTransferFrom', [
+                account.contract_address,
+                account2.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # check balance
+        execution_info = await erc721.balanceOf(account2.contract_address).execute()
+        assert execution_info.result == (to_uint(1),)
+
+        # check owner
+        execution_info = await erc721.ownerOf(TOKEN).execute()
+        assert execution_info.result == (account2.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_safeTransferFrom_invalid_uint256(self, erc721_minted):
+        erc721, account, _, erc721_holder, _ = erc721_minted
+
+        await assert_revert(
+            signer.send_transaction(
+                account, erc721.contract_address, 'safeTransferFrom', [
+                    account.contract_address,
+                    erc721_holder.contract_address,
+                    *INVALID_UINT256,
+                    len(DATA),
+                    *DATA
+                ]),
+            reverted_with="ERC721: token_id is not a valid Uint256"
+        )
+
+
+    #
+    # tokenURI
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_tokenURI(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        token_1 = TOKENS[0]
+        token_2 = TOKENS[1]
+
+        # should be zero when tokenURI is not set
+        execution_info = await erc721.tokenURI(token_1).execute()
+        assert execution_info.result == (0,)
+
+        # setTokenURI for token_1
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setTokenURI', [
+                *token_1,
+                SAMPLE_URI_1
+            ]
+        )
+
+        execution_info = await erc721.tokenURI(token_1).execute()
+        assert execution_info.result == (SAMPLE_URI_1,)
+
+        # setTokenURI for token_2
+        await signer.send_transaction(
+            account, erc721.contract_address, 'setTokenURI', [
+                *token_2,
+                SAMPLE_URI_2
+            ]
+        )
+
+        execution_info = await erc721.tokenURI(token_2).execute()
+        assert execution_info.result == (SAMPLE_URI_2,)
+
+
+    @pytest.mark.asyncio
+    async def test_tokenURI_should_revert_for_nonexistent_token(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        # should revert for nonexistent token
+        await assert_revert(
+            erc721.tokenURI(NONEXISTENT_TOKEN).execute(),
+            reverted_with="ERC721_Metadata: URI query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_setTokenURI_from_not_owner(self, erc721_minted):
+        erc721, _, not_owner, *_ = erc721_minted
+
+        await assert_revert(signer.send_transaction(
+            not_owner, erc721.contract_address, 'setTokenURI', [
+                *TOKEN,
+                SAMPLE_URI_1
+            ]),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_setTokenURI_for_nonexistent_token(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'setTokenURI', [
+                *NONEXISTENT_TOKEN,
+                SAMPLE_URI_1
+            ]),
+            reverted_with="ERC721_Metadata: set token URI for nonexistent token"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721EnumerableMintableBurnable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721EnumerableMintableBurnable.py
@@ -1,0 +1,514 @@
+import pytest
+from signers import MockSigner
+from nile.utils import (
+    MAX_UINT256, ZERO_ADDRESS, TRUE, assert_revert, to_uint, sub_uint, add_uint
+)
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted,
+    assert_events_emitted, State, Account
+)
+from ERC721BaseSuite import (
+    ERC721Base, NAME, SYMBOL, NONEXISTENT_TOKEN, DATA, RECIPIENT
+)
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+
+# random token IDs
+TOKENS = [
+    to_uint(5042), to_uint(793), to_uint(321), MAX_UINT256, to_uint(8)
+]
+TOKEN = TOKENS[0]
+# total tokens as uint
+TOTAL_TOKENS = to_uint(len(TOKENS))
+# selector id
+ENUMERABLE_INTERFACE_ID = 0x780e9d63
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc721_cls = get_contract_class('ERC721EnumerableMintableBurnable')
+    erc721_holder_cls = get_contract_class('ERC721Holder')
+    unsupported_cls = get_contract_class('Initializable')
+
+    return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_classes):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc721 = await starknet.deploy(
+        contract_class=erc721_cls,
+        constructor_calldata=[
+            NAME,                       # name
+            SYMBOL,                     # symbol
+            account1.contract_address   # owner
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_class=erc721_holder_cls,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_class=unsupported_cls,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported,
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc721_init):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc721 = cached_contract(_state, erc721_cls, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_cls, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_cls, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+@pytest.fixture
+async def erc721_minted(contract_factory):
+    erc721, account, account2, erc721_holder, unsupported = contract_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder, unsupported
+
+
+class TestERC721EnumerableMintableBurnable(ERC721Base, OwnableBase):
+    #
+    # supportsInterface
+    #
+
+    @pytest.mark.asyncio
+    async def test_supportsInterface(self, contract_factory):
+        erc721, *_ = contract_factory
+
+        execution_info = await erc721.supportsInterface(ENUMERABLE_INTERFACE_ID).execute()
+        assert execution_info.result == (TRUE,)
+
+    #
+    # totalSupply
+    #
+
+    @pytest.mark.asyncio
+    async def test_totalSupply(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        execution_info = await erc721.totalSupply().execute()
+        assert execution_info.result == (TOTAL_TOKENS,)
+
+
+    #
+    # tokenOfOwnerByIndex
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_tokenOfOwnerByIndex(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # check index
+        for i in range(0, len(TOKENS)):
+            execution_info = await erc721.tokenOfOwnerByIndex(
+                account.contract_address, to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+
+    @pytest.mark.asyncio
+    async def test_tokenOfOwnerByIndex_greater_than_supply(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        tokens_plus_one = add_uint(TOTAL_TOKENS, to_uint(1))
+
+        await assert_revert(
+            erc721.tokenOfOwnerByIndex(
+                account.contract_address, tokens_plus_one).execute(),
+            reverted_with="ERC721Enumerable: owner index out of bounds"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_tokenOfOwnerByIndex_owner_with_no_tokens(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.tokenOfOwnerByIndex(RECIPIENT, to_uint(1)).execute(),
+            reverted_with="ERC721Enumerable: owner index out of bounds"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_tokenOfOwnerByIndex_transfer_all_tokens(self, erc721_minted):
+        erc721, account, other, *_ = erc721_minted
+
+        # transfer all tokens
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'transferFrom', [
+                    account.contract_address,
+                    other.contract_address,
+                    *token
+                ]
+            )
+
+        execution_info = await erc721.balanceOf(other.contract_address).execute()
+        assert execution_info.result == (TOTAL_TOKENS,)
+
+        for i in range(0, len(TOKENS)):
+            execution_info = await erc721.tokenOfOwnerByIndex(other.contract_address, to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result == (to_uint(0),)
+
+        # check that queries to old owner's token ownership reverts since index is less
+        # than the target's balance
+        await assert_revert(erc721.tokenOfOwnerByIndex(
+            account.contract_address, to_uint(0)).execute(),
+            reverted_with="ERC721Enumerable: owner index out of bounds"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_tokenOfOwnerByIndex_safe_transfer_all_tokens(self, erc721_minted):
+        erc721, account, other, *_ = erc721_minted
+
+        # safe transfer all tokens
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'safeTransferFrom', [
+                    account.contract_address,
+                    other.contract_address,
+                    *token,
+                    len(DATA),
+                    *DATA
+                ]
+            )
+
+        execution_info = await erc721.balanceOf(other.contract_address).execute()
+        assert execution_info.result == (TOTAL_TOKENS,)
+
+        for i in range(0, len(TOKENS)):
+            execution_info = await erc721.tokenOfOwnerByIndex(other.contract_address, to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result == (to_uint(0),)
+
+        # check that queries to old owner's token ownership reverts since index is less
+        # than the target's balance
+        await assert_revert(erc721.tokenOfOwnerByIndex(
+            account.contract_address, to_uint(0)).execute(),
+            reverted_with="ERC721Enumerable: owner index out of bounds"
+        )
+
+
+    #
+    # tokenByIndex
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_tokenByIndex(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        for i in range(0, len(TOKENS)):
+            execution_info = await erc721.tokenByIndex(to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+
+    @pytest.mark.asyncio
+    async def test_tokenByIndex_greater_than_supply(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.tokenByIndex(to_uint(5)).execute(),
+            reverted_with="ERC721Enumerable: global index out of bounds"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_tokenByIndex_burn_last_token(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        tokens_minus_one = sub_uint(TOTAL_TOKENS, to_uint(1))
+
+        # burn last token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *TOKENS[4]]
+        )
+
+        execution_info = await erc721.totalSupply().execute()
+        assert execution_info.result == (tokens_minus_one,)
+
+        for i in range(0, 4):
+            execution_info = await erc721.tokenByIndex(to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+        await assert_revert(
+            erc721.tokenByIndex(tokens_minus_one).execute(),
+            reverted_with="ERC721Enumerable: global index out of bounds"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_tokenByIndex_burn_first_token(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # burn first token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *TOKENS[0]]
+        )
+
+        # TOKEN[0] should be burnt and TOKEN[4] should be swapped
+        # to TOKEN[0]'s index
+        new_token_order = [TOKENS[4], TOKENS[1], TOKENS[2], TOKENS[3]]
+        for i in range(0, 3):
+            execution_info = await erc721.tokenByIndex(to_uint(i)).execute()
+            assert execution_info.result == (new_token_order[i],)
+
+
+    @pytest.mark.asyncio
+    async def test_tokenByIndex_burn_and_mint(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'burn', [
+                    *token]
+            )
+
+        execution_info = await erc721.totalSupply().execute()
+        assert execution_info.result == (to_uint(0),)
+
+        await assert_revert(
+            erc721.tokenByIndex(to_uint(0)).execute(),
+            reverted_with="ERC721Enumerable: global index out of bounds"
+        )
+
+        # mint new tokens
+        for token in TOKENS:
+            await signer.send_transaction(
+                account, erc721.contract_address, 'mint', [
+                    account.contract_address, *token]
+            )
+
+        for i in range(0, len(TOKENS)):
+            execution_info = await erc721.tokenByIndex(to_uint(i)).execute()
+            assert execution_info.result == (TOKENS[i],)
+
+    #
+    # mint
+    #
+
+    @pytest.mark.asyncio
+    async def test_mint_emits_event(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *TOKEN]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='Transfer',
+            data=[
+                ZERO_ADDRESS,
+                account.contract_address,
+                *TOKEN
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # checks balance
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result == (to_uint(5),)
+
+        # checks that account owns correct tokens
+        for token in TOKENS:
+            execution_info = await erc721.ownerOf(token).execute()
+            assert execution_info.result == (account.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_duplicate_token_id(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting duplicate token_id should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address,
+                *TOKEN
+            ]),
+            reverted_with="ERC721: token already minted"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting to zero address should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                ZERO_ADDRESS,
+                *NONEXISTENT_TOKEN
+            ]),
+            reverted_with="ERC721: balance query for the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_approve_should_be_zero_address(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        # approved address should be zero for newly minted tokens
+        for token in TOKENS:
+            execution_info = await erc721.getApproved(token).execute()
+            assert execution_info.result == (0,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_by_not_owner(self, contract_factory):
+        erc721, _, not_owner, _, _ = contract_factory
+
+        # minting from not_owner should fail
+        await assert_revert(signer.send_transaction(
+            not_owner, erc721.contract_address, 'mint', [
+                not_owner.contract_address,
+                *TOKENS[0]
+            ]),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+
+    #
+    # burn
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_burn(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        previous_balance = execution_info.result.balance
+
+        # burn token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [*TOKEN]
+        )
+
+        # account balance should subtract one
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == sub_uint(
+            previous_balance, to_uint(1)
+        )
+
+        # approve should be cleared to zero, therefore,
+        # 'getApproved()' call should fail
+        await assert_revert(
+            erc721.getApproved(TOKEN).execute(),
+            reverted_with="ERC721: approved query for nonexistent token"
+        )
+
+        # 'token_to_burn' owner should be zero; therefore,
+        # 'ownerOf()' call should fail
+        await assert_revert(
+            erc721.ownerOf(TOKEN).execute(),
+            reverted_with="ERC721: owner query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_emits_event(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *TOKEN
+            ]
+        )
+
+        # events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc721.contract_address, 'Approval', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]],
+                [1, erc721.contract_address, 'Transfer', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]]
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_nonexistent_token(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *NONEXISTENT_TOKEN
+            ]),
+            reverted_with="ERC721: owner query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_unowned_token(self, erc721_minted):
+        erc721, account, other, *_ = erc721_minted
+
+        # other should not be able to burn account's token
+        await assert_revert(
+            signer.send_transaction(
+                other, erc721.contract_address, 'burn', [*TOKEN]
+            ),
+            reverted_with="ERC721: caller is not the token owner"
+        )
+
+        # account can burn their own token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [*TOKEN]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_zero_address(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.burn(TOKEN).execute(),
+            reverted_with="ERC721: caller is not the token owner"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721MintableBurnable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721MintableBurnable.py
@@ -1,0 +1,279 @@
+import pytest
+from signers import MockSigner
+from nile.utils import ZERO_ADDRESS, assert_revert, to_uint, sub_uint
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted,
+    assert_events_emitted, State, Account
+)
+from ERC721BaseSuite import (
+    ERC721Base, NAME, SYMBOL, NONEXISTENT_TOKEN, TOKENS, TOKEN
+)
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc721_cls = get_contract_class('ERC721MintableBurnable')
+    erc721_holder_cls = get_contract_class('ERC721Holder')
+    unsupported_cls = get_contract_class('Initializable')
+
+    return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_classes):
+    _, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc721 = await starknet.deploy(
+        contract_class=erc721_cls,
+        constructor_calldata=[
+            NAME,                       # name
+            SYMBOL,                     # symbol
+            account1.contract_address   # owner
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_class=erc721_holder_cls,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_class=unsupported_cls,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc721_init):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc721 = cached_contract(_state, erc721_cls, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_cls, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_cls, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+# Note that depending on what's being tested, test cases alternate between
+# accepting `erc721_minted` and `contract_factory` fixtures
+@pytest.fixture
+async def erc721_minted(contract_factory):
+    erc721, account, account2, erc721_holder, unsupported = contract_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder, unsupported
+
+
+class TestERC721MintableBurnable(ERC721Base, OwnableBase):
+    #
+    # mint
+    #
+
+    @pytest.mark.asyncio
+    async def test_mint_emits_event(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *TOKEN]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='Transfer',
+            data=[
+                ZERO_ADDRESS,
+                account.contract_address,
+                *TOKEN
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # checks balance
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result == (to_uint(2),)
+
+        # checks that account owns correct tokens
+        for token in TOKENS:
+            execution_info = await erc721.ownerOf(token).execute()
+            assert execution_info.result == (account.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_duplicate_token_id(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting duplicate token_id should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address,
+                *TOKEN
+            ]),
+            reverted_with="ERC721: token already minted"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting to zero address should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                ZERO_ADDRESS,
+                *NONEXISTENT_TOKEN
+            ]),
+            reverted_with="ERC721: cannot mint to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_approve_should_be_zero_address(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        # approved address should be zero for newly minted tokens
+        for token in TOKENS:
+            execution_info = await erc721.getApproved(token).execute()
+            assert execution_info.result == (0,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_by_not_owner(self, contract_factory):
+        erc721, _, not_owner, _, _ = contract_factory
+
+        # minting from not_owner should fail
+        await assert_revert(signer.send_transaction(
+            not_owner, erc721.contract_address, 'mint', [
+                not_owner.contract_address,
+                *TOKENS[0]
+            ]),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+
+    #
+    # burn
+    #
+
+
+    @pytest.mark.asyncio
+    async def test_burn(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        previous_balance = execution_info.result.balance
+
+        # burn token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [*TOKEN]
+        )
+
+        # account balance should subtract one
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result.balance == sub_uint(
+            previous_balance, to_uint(1)
+        )
+
+        # approve should be cleared to zero, therefore,
+        # 'getApproved()' call should fail
+        await assert_revert(
+            erc721.getApproved(TOKEN).execute(),
+            reverted_with="ERC721: approved query for nonexistent token"
+        )
+
+        # 'token_to_burn' owner should be zero; therefore,
+        # 'ownerOf()' call should fail
+        await assert_revert(
+            erc721.ownerOf(TOKEN).execute(),
+            reverted_with="ERC721: owner query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_emits_event(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *TOKEN
+            ]
+        )
+
+        # events
+        assert_events_emitted(
+            tx_exec_info,
+            [
+                [0, erc721.contract_address, 'Approval', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]],
+                [1, erc721.contract_address, 'Transfer', [
+                    account.contract_address, ZERO_ADDRESS, *TOKEN]]
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_nonexistent_token(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'burn', [
+                *NONEXISTENT_TOKEN
+            ]),
+            reverted_with="ERC721: owner query for nonexistent token"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_unowned_token(self, erc721_minted):
+        erc721, account, other, *_ = erc721_minted
+
+        # other should not be able to burn account's token
+        await assert_revert(
+            signer.send_transaction(
+                other, erc721.contract_address, 'burn', [*TOKEN]
+            ),
+            reverted_with="ERC721: caller is not the token owner"
+        )
+
+        # account can burn their own token
+        await signer.send_transaction(
+            account, erc721.contract_address, 'burn', [*TOKEN]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_burn_from_zero_address(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        await assert_revert(
+            erc721.burn(TOKEN).execute(),
+            reverted_with="ERC721: caller is not the token owner"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721MintablePausable.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721MintablePausable.py
@@ -1,0 +1,314 @@
+import pytest
+from signers import MockSigner
+from nile.utils import TRUE, FALSE, ZERO_ADDRESS, assert_revert, to_uint
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted, State, Account
+)
+from ERC721BaseSuite import (
+    ERC721Base, NAME, SYMBOL, TOKENS, TOKEN, NONEXISTENT_TOKEN, DATA
+)
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+# testing vars
+TOKEN_TO_MINT = to_uint(33)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc721_cls = get_contract_class('ERC721MintablePausable')
+    erc721_holder_cls = get_contract_class('ERC721Holder')
+    unsupported_cls = get_contract_class('Initializable')
+
+    return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_classes):
+    _, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc721 = await starknet.deploy(
+        contract_class=erc721_cls,
+        constructor_calldata=[
+            NAME,                       # name
+            SYMBOL,                     # ticker
+            account1.contract_address   # owner
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_class=erc721_holder_cls,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_class=unsupported_cls,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported,
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc721_init):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc721 = cached_contract(_state, erc721_cls, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_cls, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_cls, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+@pytest.fixture
+async def erc721_minted(contract_factory):
+    erc721, account, account2, erc721_holder, unsupported = contract_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder, unsupported
+
+
+class TestERC721MintablePausable(ERC721Base, OwnableBase):
+    #
+    # mint
+    #
+
+    @pytest.mark.asyncio
+    async def test_mint_emits_event(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # mint token to account
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *TOKEN]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='Transfer',
+            data=[
+                ZERO_ADDRESS,
+                account.contract_address,
+                *TOKEN
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # checks balance
+        execution_info = await erc721.balanceOf(account.contract_address).execute()
+        assert execution_info.result == (to_uint(2),)
+
+        # checks that account owns correct tokens
+        for token in TOKENS:
+            execution_info = await erc721.ownerOf(token).execute()
+            assert execution_info.result == (account.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_duplicate_token_id(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting duplicate token_id should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address,
+                *TOKEN
+            ]),
+            reverted_with="ERC721: token already minted"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_to_zero_address(self, erc721_minted):
+        erc721, account, *_ = erc721_minted
+
+        # minting to zero address should fail
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                ZERO_ADDRESS,
+                *NONEXISTENT_TOKEN
+            ]),
+            reverted_with="ERC721: cannot mint to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_mint_approve_should_be_zero_address(self, erc721_minted):
+        erc721, *_ = erc721_minted
+
+        # approved address should be zero for newly minted tokens
+        for token in TOKENS:
+            execution_info = await erc721.getApproved(token).execute()
+            assert execution_info.result == (0,)
+
+
+    @pytest.mark.asyncio
+    async def test_mint_by_not_owner(self, contract_factory):
+        erc721, _, not_owner, _, _ = contract_factory
+
+        # minting from not_owner should fail
+        await assert_revert(signer.send_transaction(
+            not_owner, erc721.contract_address, 'mint', [
+                not_owner.contract_address,
+                *TOKENS[0]
+            ]),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+    #
+    # pause
+    #
+
+    @pytest.mark.asyncio
+    async def test_pause(self, erc721_minted):
+        erc721, owner, other, erc721_holder, _ = erc721_minted
+
+        # pause
+        await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+        execution_info = await erc721.paused().execute()
+        assert execution_info.result.paused == TRUE
+
+        await assert_revert(signer.send_transaction(
+            owner, erc721.contract_address, 'approve', [
+                other.contract_address,
+                *TOKENS[0]
+            ]),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner, erc721.contract_address, 'setApprovalForAll', [
+                other.contract_address,
+                TRUE
+            ]),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner, erc721.contract_address, 'transferFrom', [
+                owner.contract_address,
+                other.contract_address,
+                *TOKENS[0]
+            ]),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner, erc721.contract_address, 'safeTransferFrom', [
+                owner.contract_address,
+                erc721_holder.contract_address,
+                *TOKENS[1],
+                len(DATA),
+                *DATA
+            ]),
+            reverted_with="Pausable: paused"
+        )
+
+        await assert_revert(signer.send_transaction(
+            owner, erc721.contract_address, 'mint', [
+                other.contract_address,
+                *TOKEN_TO_MINT
+            ]),
+            reverted_with="Pausable: paused"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_unpause(self, erc721_minted):
+        erc721, owner, other, erc721_holder, _ = erc721_minted
+
+        # pause
+        await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+        # unpause
+        await signer.send_transaction(owner, erc721.contract_address, 'unpause', [])
+
+        execution_info = await erc721.paused().execute()
+        assert execution_info.result.paused == FALSE
+
+        await signer.send_transaction(
+            owner, erc721.contract_address, 'approve', [
+                other.contract_address,
+                *TOKENS[0]
+            ]
+        )
+
+        await signer.send_transaction(
+            owner, erc721.contract_address, 'setApprovalForAll', [
+                other.contract_address,
+                TRUE
+            ]
+        )
+
+        await signer.send_transaction(
+            owner, erc721.contract_address, 'transferFrom', [
+                owner.contract_address,
+                other.contract_address,
+                *TOKENS[0]
+            ]
+        )
+
+        await signer.send_transaction(
+            other, erc721.contract_address, 'safeTransferFrom', [
+                owner.contract_address,
+                erc721_holder.contract_address,
+                *TOKENS[1],
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        await signer.send_transaction(
+            owner, erc721.contract_address, 'mint', [
+                other.contract_address,
+                *TOKEN_TO_MINT
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_only_owner(self, erc721_minted):
+        erc721, owner, other, *_ = erc721_minted
+
+        # not-owner pause should revert
+        await assert_revert(
+            signer.send_transaction(
+                other, erc721.contract_address, 'pause', []),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+        # owner pause
+        await signer.send_transaction(owner, erc721.contract_address, 'pause', [])
+
+        # not-owner unpause should revert
+        await assert_revert(
+            signer.send_transaction(
+                other, erc721.contract_address, 'unpause', []),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+        # owner unpause
+        await signer.send_transaction(owner, erc721.contract_address, 'unpause', [])

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721SafeMintableMock.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/token/erc721/test_ERC721SafeMintableMock.py
@@ -1,0 +1,231 @@
+import pytest
+from signers import MockSigner
+from nile.utils import (
+    ZERO_ADDRESS, INVALID_UINT256, assert_revert, to_uint
+)
+from utils import (
+    get_contract_class, cached_contract, assert_event_emitted, State, Account
+)
+from ERC721BaseSuite import ERC721Base, NAME, SYMBOL, DATA, TOKEN, TOKENS
+from access.OwnableBaseSuite import OwnableBase
+
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    erc721_cls = get_contract_class('ERC721SafeMintableMock')
+    erc721_holder_cls = get_contract_class('ERC721Holder')
+    unsupported_cls = get_contract_class('Initializable')
+
+    return account_cls, erc721_cls, erc721_holder_cls, unsupported_cls
+
+
+@pytest.fixture(scope='module')
+async def erc721_init(contract_classes):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    starknet = await State.init()
+    account1 = await Account.deploy(signer.public_key)
+    account2 = await Account.deploy(signer.public_key)
+    erc721 = await starknet.deploy(
+        contract_class=erc721_cls,
+        constructor_calldata=[
+            NAME,                       # name
+            SYMBOL,                     # ticker
+            account1.contract_address   # owner
+        ]
+    )
+    erc721_holder = await starknet.deploy(
+        contract_class=erc721_holder_cls,
+        constructor_calldata=[]
+    )
+    unsupported = await starknet.deploy(
+        contract_class=unsupported_cls,
+        constructor_calldata=[]
+    )
+    return (
+        starknet.state,
+        account1,
+        account2,
+        erc721,
+        erc721_holder,
+        unsupported
+    )
+
+
+@pytest.fixture
+def contract_factory(contract_classes, erc721_init):
+    account_cls, erc721_cls, erc721_holder_cls, unsupported_cls = contract_classes
+    state, account1, account2, erc721, erc721_holder, unsupported = erc721_init
+    _state = state.copy()
+    account1 = cached_contract(_state, account_cls, account1)
+    account2 = cached_contract(_state, account_cls, account2)
+    erc721 = cached_contract(_state, erc721_cls, erc721)
+    erc721_holder = cached_contract(_state, erc721_holder_cls, erc721_holder)
+    unsupported = cached_contract(_state, unsupported_cls, unsupported)
+
+    return erc721, account1, account2, erc721_holder, unsupported
+
+
+@pytest.fixture
+async def erc721_minted(contract_factory):
+    erc721, account, account2, erc721_holder, unsupported = contract_factory
+    # mint tokens to account
+    for token in TOKENS:
+        await signer.send_transaction(
+            account, erc721.contract_address, 'mint', [
+                account.contract_address, *token]
+        )
+
+    return erc721, account, account2, erc721_holder, unsupported
+
+
+class TestERC721SafeMintableMock(ERC721Base, OwnableBase):
+    #
+    # safeMint
+    #
+
+    @pytest.mark.asyncio
+    async def test_safeMint_to_erc721_supported_contract(self, contract_factory):
+        erc721, account, _, erc721_holder, _ = contract_factory
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # check balance
+        execution_info = await erc721.balanceOf(erc721_holder.contract_address).call()
+        assert execution_info.result == (to_uint(1),)
+
+        # check owner
+        execution_info = await erc721.ownerOf(TOKEN).call()
+        assert execution_info.result == (erc721_holder.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_emits_event(self, contract_factory):
+        erc721, account, _, erc721_holder, _ = contract_factory
+
+        tx_exec_info = await signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=erc721.contract_address,
+            name='Transfer',
+            data=[
+                ZERO_ADDRESS,
+                erc721_holder.contract_address,
+                *TOKEN
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_to_account(self, contract_factory):
+        erc721, account, recipient, _, _ = contract_factory
+
+        await signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                recipient.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]
+        )
+
+        # check balance
+        execution_info = await erc721.balanceOf(recipient.contract_address).call()
+        assert execution_info.result == (to_uint(1),)
+
+        # check owner
+        execution_info = await erc721.ownerOf(TOKEN).call()
+        assert execution_info.result == (recipient.contract_address,)
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_to_zero_address(self, contract_factory):
+        erc721, account, _, _, _ = contract_factory
+
+        # to zero address should be rejected
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                ZERO_ADDRESS,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]),
+            reverted_with="ERC721: cannot mint to the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_from_zero_address(self, contract_factory):
+        erc721, _, _, erc721_holder, _ = contract_factory
+
+        # Caller address is `0` when not using an account contract
+        await assert_revert(
+            erc721.safeMint(
+                erc721_holder.contract_address,
+                TOKEN,
+                DATA
+            ).execute(),
+            reverted_with="Ownable: caller is the zero address"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_from_not_owner(self, contract_factory):
+        erc721, _, other, erc721_holder, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            other, erc721.contract_address, 'safeMint', [
+                erc721_holder.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ]),
+            reverted_with="Ownable: caller is not the owner"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_to_unsupported_contract(self, contract_factory):
+        erc721, account, _, _, unsupported = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                unsupported.contract_address,
+                *TOKEN,
+                len(DATA),
+                *DATA
+            ])
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_safeMint_invalid_uint256(self, contract_factory):
+        erc721, account, recipient, _, _ = contract_factory
+
+        await assert_revert(signer.send_transaction(
+            account, erc721.contract_address, 'safeMint', [
+                recipient.contract_address,
+                *INVALID_UINT256,
+                len(DATA),
+                *DATA
+            ]),
+            reverted_with="ERC721: token_id is not a valid Uint256"
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/upgrades/test_Proxy.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/upgrades/test_Proxy.py
@@ -1,0 +1,167 @@
+import pytest
+from starkware.starknet.public.abi import get_selector_from_name
+from signers import MockSigner
+from nile.utils import (
+    assert_revert, assert_revert_entry_point
+)
+from utils import (
+    get_contract_class,
+    cached_contract,
+    assert_event_emitted,
+    State,
+    Account
+)
+
+# random value
+VALUE = 123
+
+signer = MockSigner(123456789987654321)
+
+class TestProxy:
+    @pytest.fixture(scope='module')
+    def contract_classes(self):
+        account_cls = Account.get_class
+        implementation_cls = get_contract_class('ProxiableImplementation')
+        proxy_cls = get_contract_class('Proxy')
+
+        return account_cls, implementation_cls, proxy_cls
+
+
+    @pytest.fixture(scope='module')
+    async def proxy_init(self, contract_classes):
+        account_cls, implementation_cls, proxy_cls = contract_classes
+        starknet = await State.init()
+        account1 = await Account.deploy(signer.public_key)
+        account2 = await Account.deploy(signer.public_key)
+        implementation_decl = await starknet.declare(
+            contract_class=implementation_cls
+        )
+        selector = get_selector_from_name('initializer')
+        params = [
+            account1.contract_address   # admin account
+        ]
+        proxy = await starknet.deploy(
+            contract_class=proxy_cls,
+            constructor_calldata=[
+                implementation_decl.class_hash,
+                selector,
+                len(params),
+                *params
+            ]
+        )
+        return (
+            starknet.state,
+            account1,
+            account2,
+            proxy
+        )
+
+
+    @pytest.fixture
+    def proxy_factory(self, contract_classes, proxy_init):
+        account_cls, _, proxy_cls = contract_classes
+        state, account1, account2, proxy = proxy_init
+        _state = state.copy()
+        admin = cached_contract(_state, account_cls, account1)
+        other = cached_contract(_state, account_cls, account2)
+        proxy = cached_contract(_state, proxy_cls, proxy)
+
+        return admin, other, proxy
+
+
+    #
+    # initializer
+    #
+
+    @pytest.mark.asyncio
+    async def test_initializer(self, proxy_factory):
+        admin, _, proxy = proxy_factory
+
+        # check admin is set
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getAdmin', []
+        )
+        assert execution_info.call_info.retdata[1] == admin.contract_address
+
+
+    @pytest.mark.asyncio
+    async def test_initializer_after_initialized(self, proxy_factory):
+        admin, _, proxy = proxy_factory
+
+        await assert_revert(signer.send_transaction(
+            admin, proxy.contract_address, 'initializer', [admin.contract_address]),
+            reverted_with="Proxy: contract already initialized"
+        )
+
+    #
+    # set_admin
+    #
+
+    @pytest.mark.asyncio
+    async def test_set_admin(self, proxy_factory):
+        admin, _, proxy = proxy_factory
+
+        # set admin
+        tx_exec_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'setAdmin', [VALUE]
+        )
+
+        # check event
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=proxy.contract_address,
+            name='AdminChanged',
+            data=[
+                admin.contract_address,       # old admin
+                VALUE                         # new admin
+            ]
+        )
+
+        # check new admin
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getAdmin', []
+        )
+        assert execution_info.call_info.retdata[1] == VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_set_admin_from_unauthorized(self, proxy_factory):
+        _, non_admin, proxy = proxy_factory
+
+        # set admin
+        await assert_revert(signer.send_transaction(
+            non_admin, proxy.contract_address, 'setAdmin', [VALUE]),
+            reverted_with="Proxy: caller is not admin"
+        )
+
+    #
+    # fallback function
+    #
+
+    @pytest.mark.asyncio
+    async def test_default_fallback(self, proxy_factory):
+        admin, _, proxy = proxy_factory
+
+        # set value through proxy
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'setValue', [VALUE]
+        )
+
+        # get value through proxy
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getValue', []
+        )
+        assert execution_info.call_info.retdata[1] == VALUE
+
+
+    @pytest.mark.asyncio
+    async def test_fallback_when_selector_does_not_exist(self, proxy_factory):
+        admin, _, proxy = proxy_factory
+
+        # should fail with entry point error
+        await assert_revert_entry_point(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'invalid_selector', []
+            ),
+            invalid_selector='invalid_selector'
+        )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/upgrades/test_upgrades.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/upgrades/test_upgrades.py
@@ -1,0 +1,368 @@
+import pytest
+from signers import MockSigner
+from starkware.starknet.public.abi import get_selector_from_name
+from nile.utils import assert_revert, assert_revert_entry_point, FALSE, TRUE
+from utils import (
+    State,
+    Account,
+    assert_event_emitted,
+    get_contract_class,
+    cached_contract,
+)
+
+
+# random value
+VALUE_1 = 123
+VALUE_2 = 987
+
+signer = MockSigner(123456789987654321)
+
+
+class TestUpgrades:
+    @pytest.fixture(scope='module')
+    def contract_classes(self):
+        account_cls = Account.get_class
+        v1_cls = get_contract_class('UpgradesMockV1')
+        v2_cls = get_contract_class('UpgradesMockV2')
+        proxy_cls = get_contract_class('Proxy')
+
+        return account_cls, v1_cls, v2_cls, proxy_cls
+
+
+    @pytest.fixture(scope='module')
+    async def implementations_declare(self, contract_classes):
+        _, v1_cls, v2_cls, proxy_cls = contract_classes
+        starknet = await State.init()
+        account1 = await Account.deploy(signer.public_key)
+        account2 = await Account.deploy(signer.public_key)
+
+        v1_decl = await starknet.declare(
+            contract_class=v1_cls,
+        )
+        v2_decl = await starknet.declare(
+            contract_class=v2_cls,
+        )
+
+        return (
+            starknet,
+            account1,
+            account2,
+            v1_decl,
+            v2_decl,
+            proxy_cls
+        )
+
+
+    @pytest.fixture(scope='module')
+    async def proxy_deploy(self, implementations_declare):
+        starknet, _, _, v1_decl, _, proxy_cls = implementations_declare
+
+        # with selector set to 0, internal initialization call must be ignored
+        proxy = await starknet.deploy(
+            contract_class=proxy_cls,
+            constructor_calldata=[
+                v1_decl.class_hash,
+                0,
+                0,
+                *[]
+            ]
+        )
+        return proxy
+
+
+    @pytest.fixture(scope='module')
+    async def proxy_init(self, implementations_declare):
+        starknet, account1, account2, v1_decl, v2_decl, proxy_cls = implementations_declare
+
+        selector = get_selector_from_name('initializer')
+        params = [
+            account1.contract_address   # admin account
+        ]
+        proxy = await starknet.deploy(
+            contract_class=proxy_cls,
+            constructor_calldata=[
+                v1_decl.class_hash,
+                selector,
+                len(params),
+                *params
+            ]
+        )
+        return (
+            starknet.state,
+            account1,
+            account2,
+            v1_decl,
+            v2_decl,
+            proxy
+        )
+
+
+    @pytest.fixture
+    def proxy_factory(self, contract_classes, proxy_init, proxy_deploy):
+        account_cls, _, _, proxy_cls = contract_classes
+        state, account1, account2, v1_decl, v2_decl, proxy = proxy_init
+        non_initialized_proxy = proxy_deploy
+
+        _state = state.copy()
+        account1 = cached_contract(_state, account_cls, account1)
+        account2 = cached_contract(_state, account_cls, account2)
+        proxy = cached_contract(_state, proxy_cls, proxy)
+
+        return account1, account2, proxy, non_initialized_proxy, v1_decl, v2_decl
+
+
+    @pytest.fixture
+    async def after_upgrade(self, proxy_factory):
+        admin, other, proxy, _, v1_decl, v2_decl = proxy_factory
+
+        # set value, and upgrade to v2
+        await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'setValue1', [VALUE_1]),
+                (proxy.contract_address, 'upgrade', [v2_decl.class_hash])
+            ]
+        )
+
+        return admin, other, proxy, v1_decl, v2_decl
+
+
+    @pytest.mark.asyncio
+    async def test_deployment_without_initialization(self, proxy_factory):
+        admin, _, _, proxy, *_ = proxy_factory
+
+        # assert not initialized yet
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'initialized', []
+        )
+        assert execution_info.call_info.retdata[1] == FALSE
+
+        # initialize
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'initializer', [admin.contract_address],
+        )
+
+        # assert initialized
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'initialized', []
+        )
+        assert execution_info.call_info.retdata[1] == TRUE
+
+
+    @pytest.mark.asyncio
+    async def test_initializer_already_initialized(self, proxy_factory):
+        admin, _, proxy, *_ = proxy_factory
+
+        await assert_revert(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'initializer', [
+                    admin.contract_address
+                ]
+            ),
+            reverted_with='Proxy: contract already initialized'
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade(self, proxy_factory):
+        admin, _, proxy, _, _, v2_decl = proxy_factory
+
+        # set value
+        await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'setValue1', [VALUE_1]),
+            ]
+        )
+
+        # check value
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getValue1', []
+        )
+        assert execution_info.call_info.retdata[1] == VALUE_1
+
+        # upgrade
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'upgrade', [
+                v2_decl.class_hash
+            ]
+        )
+
+        # check value
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getValue1', []
+        )
+        assert execution_info.call_info.retdata[1] == VALUE_1
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade_event(self, proxy_factory):
+        admin, _, proxy, _, _, v2_decl = proxy_factory
+
+        # upgrade
+        tx_exec_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'upgrade', [
+                v2_decl.class_hash
+            ]
+        )
+
+        # check event
+        assert_event_emitted(
+            tx_exec_info,
+            from_address=proxy.contract_address,
+            name='Upgraded',
+            data=[
+                v2_decl.class_hash          # new class hash
+            ]
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_upgrade_from_non_admin(self, proxy_factory):
+        _, non_admin, proxy, _, _, v2_decl = proxy_factory
+
+        # upgrade should revert
+        await assert_revert(
+            signer.send_transaction(
+                non_admin, proxy.contract_address, 'upgrade', [
+                    v2_decl.class_hash
+                ]
+            ),
+            reverted_with="Proxy: caller is not admin"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_set_implementation_as_zero(self, proxy_factory):
+        admin, _, proxy, *_ = proxy_factory
+
+        # upgrade should revert
+        await assert_revert(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'upgrade', [0]
+            ),
+            reverted_with="Proxy: implementation hash cannot be zero"
+        )
+
+    @pytest.mark.asyncio
+    async def test_implementation_v2(self, after_upgrade):
+        admin, _, proxy, _, v2_decl = after_upgrade
+
+        execution_info = await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'getImplementationHash', []),
+                (proxy.contract_address, 'getAdmin', []),
+                (proxy.contract_address, 'getValue1', [])
+            ]
+        )
+
+        expected = [
+            3,                              # number of return values
+            v2_decl.class_hash,             # getImplementationHash
+            admin.contract_address,         # getAdmin
+            VALUE_1                         # getValue1
+        ]
+
+        assert execution_info.call_info.retdata == expected
+
+    #
+    # v2 functions
+    #
+
+    @pytest.mark.asyncio
+    async def test_set_admin(self, after_upgrade):
+        admin, new_admin, proxy, *_ = after_upgrade
+
+        # change admin
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'setAdmin', [
+                new_admin.contract_address
+            ]
+        )
+
+        # check admin
+        execution_info = await signer.send_transaction(
+            admin, proxy.contract_address, 'getAdmin', []
+        )
+        assert execution_info.call_info.retdata[1] == new_admin.contract_address
+
+
+    @pytest.mark.asyncio
+    async def test_set_admin_from_non_admin(self, after_upgrade):
+        _, non_admin, proxy, *_ = after_upgrade
+
+        # should revert
+        await assert_revert(signer.send_transaction(
+            non_admin, proxy.contract_address, 'setAdmin', [non_admin.contract_address]),
+            reverted_with="Proxy: caller is not admin"
+        )
+
+
+    @pytest.mark.asyncio
+    async def test_v2_functions_pre_and_post_upgrade(self, proxy_factory):
+        admin, new_admin, proxy, _, _, v2_decl = proxy_factory
+
+        # check getValue2 doesn't exist
+        await assert_revert_entry_point(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'getValue2', []
+            ),
+            invalid_selector='getValue2'
+        )
+
+        # check setValue2 doesn't exist in v1
+        await assert_revert_entry_point(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'setValue2', [VALUE_2]
+            ),
+            invalid_selector='setValue2'
+        )
+
+        # check getAdmin doesn't exist in v1
+        await assert_revert_entry_point(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'getAdmin', []
+            ),
+            invalid_selector='getAdmin'
+        )
+
+        # check setAdmin doesn't exist in v1
+        await assert_revert_entry_point(
+            signer.send_transaction(
+                admin, proxy.contract_address, 'setAdmin', [new_admin.contract_address]
+            ),
+            invalid_selector='setAdmin'
+        )
+
+        # upgrade
+        await signer.send_transaction(
+            admin, proxy.contract_address, 'upgrade', [
+                v2_decl.class_hash
+            ]
+        )
+
+        # set value 2 and admin
+        await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'setValue2', [VALUE_2]),
+                (proxy.contract_address, 'setAdmin', [new_admin.contract_address])
+            ]
+        )
+
+        # check value 2 and admin
+        execution_info = await signer.send_transactions(
+            admin,
+            [
+                (proxy.contract_address, 'getValue2', []),
+                (proxy.contract_address, 'getAdmin', [])
+            ]
+        )
+
+        expected = [
+            2,                              # number of return values
+            VALUE_2,                        # getValue2
+            new_admin.contract_address      # getAdmin
+        ]
+        assert execution_info.call_info.retdata == expected

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/utils.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/utils.py
@@ -1,0 +1,154 @@
+"""Utilities for testing Cairo contracts."""
+
+import os
+from pathlib import Path
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
+from starkware.starknet.core.os.class_hash import compute_class_hash
+from starkware.starknet.public.abi import get_selector_from_name
+from starkware.starknet.business_logic.execution.objects import OrderedEvent
+from starkware.starknet.compiler.compile import compile_starknet_files
+from starkware.starknet.testing.starknet import StarknetContract
+from starkware.starknet.testing.starknet import Starknet
+
+
+
+MAX_UINT256 = (2**128 - 1, 2**128 - 1)
+INVALID_UINT256 = (MAX_UINT256[0] + 1, MAX_UINT256[1])
+ZERO_ADDRESS = 0
+TRUE = 1
+FALSE = 0
+IACCOUNT_ID = 0xa66bd575
+
+_root = Path(__file__).parent.parent
+
+
+def get_cairo_path():
+    CAIRO_PATH = os.getenv('CAIRO_PATH')
+    cairo_path = []
+
+    if CAIRO_PATH is not None:
+        cairo_path = [p for p in CAIRO_PATH.split(":")]
+
+    return cairo_path
+
+def contract_path(name):
+    if name.startswith("tests/"):
+        return str(_root / name)
+    else:
+        return str(_root / "src" / name)
+
+
+def assert_event_emitted(tx_exec_info, from_address, name, data, order=0):
+    """Assert one single event is fired with correct data."""
+    assert_events_emitted(tx_exec_info, [(order, from_address, name, data)])
+
+
+def assert_events_emitted(tx_exec_info, events):
+    """Assert events are fired with correct data."""
+    for event in events:
+        order, from_address, name, data = event
+        event_obj = OrderedEvent(
+            order=order,
+            keys=[get_selector_from_name(name)],
+            data=data,
+        )
+
+        base = tx_exec_info.call_info.internal_calls[0]
+        if event_obj in base.events and from_address == base.contract_address:
+            return
+
+        try:
+            base2 = base.internal_calls[0]
+            if event_obj in base2.events and from_address == base2.contract_address:
+                return
+        except IndexError:
+            pass
+
+        raise BaseException("Event not fired or not fired correctly")
+
+
+def _get_path_from_name(name):
+    """Return the contract path by contract name."""
+    dirs = ["src", "tests/mocks"]
+    for dir in dirs:
+        for (dirpath, _, filenames) in os.walk(dir):
+            for file in filenames:
+                if file == f"{name}.cairo":
+                    return os.path.join(dirpath, file)
+
+    raise FileNotFoundError(f"Cannot find '{name}'.")
+
+
+def get_contract_class(contract, is_path=False):
+    """Return the contract class from the contract name or path"""
+    if is_path:
+        path = contract_path(contract)
+    else:
+        path = _get_path_from_name(contract)
+
+    contract_class = compile_starknet_files(
+        files=[path],
+        debug_info=True,
+        cairo_path=get_cairo_path()
+    )
+    return contract_class
+
+
+def get_class_hash(contract_name, is_path=False):
+    """Return the class_hash for a given contract."""
+    contract_class = get_contract_class(contract_name, is_path)
+    return compute_class_hash(contract_class=contract_class, hash_func=pedersen_hash)
+
+
+def cached_contract(state, _class, deployed):
+    """Return the cached contract"""
+    contract = StarknetContract(
+        state=state,
+        abi=_class.abi,
+        contract_address=deployed.contract_address,
+        deploy_call_info=deployed.deploy_call_info
+    )
+    return contract
+
+
+class State:
+    """
+    Utility helper for Account class to initialize and return StarkNet state.
+
+    Example
+    ---------
+    Initalize StarkNet state
+
+    >>> starknet = await State.init()
+
+    """
+    async def init():
+        global starknet
+        starknet = await Starknet.empty()
+        return starknet
+
+
+class Account:
+    """
+    Utility for deploying Account contract.
+
+    Parameters
+    ----------
+
+    public_key : int
+
+    Examples
+    ----------
+
+    >>> starknet = await State.init()
+    >>> account = await Account.deploy(public_key)
+
+    """
+    get_class = get_contract_class("Account")
+
+    async def deploy(public_key):
+        account = await starknet.deploy(
+            contract_class=Account.get_class,
+            constructor_calldata=[public_key]
+        )
+        return account

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/utils/test_UniversalDeployer.py
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tests/utils/test_UniversalDeployer.py
@@ -1,0 +1,102 @@
+import pytest
+from starkware.starknet.core.os.contract_address.contract_address import calculate_contract_address_from_hash
+from starkware.crypto.signature.fast_pedersen_hash import pedersen_hash
+from starkware.starknet.core.os.class_hash import compute_class_hash
+
+from signers import MockSigner
+from utils import (
+    State,
+    Account,
+    get_contract_class,
+    assert_event_emitted,
+    cached_contract,
+    IACCOUNT_ID,
+    FALSE,
+    TRUE,
+)
+
+signer = MockSigner(123456789987654321)
+
+
+@pytest.fixture(scope='module')
+def contract_classes():
+    account_cls = Account.get_class
+    deployer_cls = get_contract_class('UniversalDeployer')
+
+    return account_cls, deployer_cls
+
+
+@pytest.fixture(scope='module')
+async def deployer_init(contract_classes):
+    _, deployer_cls = contract_classes
+    starknet = await State.init()
+    account = await Account.deploy(signer.public_key)
+    deployer = await starknet.deploy(contract_class=deployer_cls)
+    return (
+        starknet.state,
+        account,
+        deployer
+    )
+
+
+@pytest.fixture
+def deployer_factory(contract_classes, deployer_init):
+    account_cls, deployer_cls = contract_classes
+    state, account, deployer = deployer_init
+    _state = state.copy()
+    _account = cached_contract(_state, account_cls, account)
+    deployer = cached_contract(_state, deployer_cls, deployer)
+
+    return _account, deployer
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('unique', [TRUE, FALSE])
+async def test_deployment(deployer_factory, unique):
+    account, deployer = deployer_factory
+    salt = 1234567875432  # random value
+    calldata = [signer.public_key]
+    class_hash = compute_class_hash(
+        contract_class=Account.get_class, hash_func=pedersen_hash)
+
+    # deploy contract
+    params = [class_hash, salt, unique, len(calldata), *calldata]
+    deploy_exec_info = await signer.send_transaction(account, deployer.contract_address, 'deployContract', params)
+    deployed_address = deploy_exec_info.call_info.retdata[1]
+
+    # check address
+    if unique:
+        actual_salt = pedersen_hash(account.contract_address, salt)
+        deployer_address = deployer.contract_address
+    else:
+        actual_salt = salt
+        deployer_address = 0
+
+    expected_address = calculate_contract_address_from_hash(
+        salt=actual_salt,
+        class_hash=class_hash,
+        constructor_calldata=calldata,
+        deployer_address=deployer_address
+    )
+
+    assert deployed_address == expected_address
+
+    # check deployment
+    tx_exec_info = await signer.send_transaction(account, deployed_address, 'supportsInterface', [IACCOUNT_ID])
+    is_account = tx_exec_info.call_info.retdata[1]
+    assert is_account == TRUE
+
+    assert_event_emitted(
+        deploy_exec_info,
+        from_address=deployer.contract_address,
+        name='ContractDeployed',
+        data=[
+            deployed_address,         # contractAddress
+            account.contract_address, # deployer
+            unique,                   # unique
+            class_hash,               # classHash
+            len(calldata),            # calldata_len
+            *calldata,                # calldata
+            salt,                     # salt
+        ]
+    )

--- a/src/contracts/sbt-ERC1155/lib/cairo_contracts/tox.ini
+++ b/src/contracts/sbt-ERC1155/lib/cairo_contracts/tox.ini
@@ -1,0 +1,63 @@
+[tox]
+minversion = 3.15
+envlist = default
+isolated_build = True
+
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning
+addopts= -n auto
+asyncio_mode = auto
+markers =
+    only: marks a subset of tests to run (development purpose)
+
+[testenv]
+description = Invoke pytest to run automated tests
+setenv =
+    TOXINIDIR = {toxinidir}
+passenv =
+    HOME
+    PYTHONPATH
+deps =
+    cairo-lang==0.10.1
+    cairo-nile==0.11.0
+    pytest-xdist
+    # See https://github.com/starkware-libs/cairo-lang/issues/52
+    marshmallow-dataclass==8.5.3
+extras =
+    testing
+commands =
+    nile compile --directory src/
+    pytest {posargs}
+
+[testenv:coverage]
+description = Invoke nile-coverage to generate coverage report
+skip_install = True
+setenv =
+    {[testenv]setenv}
+    CAIRO_PATH = src
+deps =
+    {[testenv]deps}
+    nile-coverage==0.2.4
+commands =
+    nile compile --directory src/
+    nile coverage -c src {posargs}
+
+[testenv:build]
+description = Build the package in isolation according to PEP517, see https://github.com/pypa/build
+skip_install = True
+changedir = {toxinidir}
+deps =
+    build[virtualenv]
+    twine
+commands =
+    python -m build . -o dist
+    python -m twine check --strict dist/*
+
+[testenv:lint]
+description = Lint Markdown documents following the rules set forth here: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+changedir = {toxinidir}
+allowlist_externals =
+    npx
+commands =
+    npx markdownlint-cli README.md CONTRIBUTING.md docs -i docs/node_modules

--- a/src/contracts/sbt-ERC1155/protostar.toml
+++ b/src/contracts/sbt-ERC1155/protostar.toml
@@ -1,0 +1,11 @@
+[project]
+protostar-version = "0.9.1"
+lib-path = "lib"
+cairo-path = ["lib/cairo_contracts/src"]
+
+[contracts]
+SBT = ["src/SBT.cairo"]
+
+[profile.devnet.project]
+gateway-url = "http://127.0.0.1:5050/"
+chain-id = 1536727068981429685321

--- a/src/contracts/sbt-ERC1155/src/SBT.cairo
+++ b/src/contracts/sbt-ERC1155/src/SBT.cairo
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/presets/ERC1155MintableBurnable.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256, assert_uint256_lt
+from starkware.cairo.common.math import assert_le, assert_not_zero
+
+from openzeppelin.access.ownable.library import Ownable
+from openzeppelin.token.erc1155.library import ERC1155
+from openzeppelin.introspection.erc165.library import ERC165
+
+//
+// Constructor
+//
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    uri: felt, owner: felt
+) {
+    ERC1155.initializer(uri);
+    Ownable.initializer(owner);
+    return ();
+}
+
+//
+// Getters
+//
+
+// ERC165
+@view
+func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    interfaceId: felt
+) -> (success: felt) {
+    return ERC165.supports_interface(interfaceId);
+}
+
+// Returns the same URI for all token types.
+@view
+func uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: Uint256) -> (
+    uri: felt
+) {
+    return ERC1155.uri(id);
+}
+
+// Returns the amount of tokens of token type id owned by account.
+@view
+func balanceOf{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, id: Uint256
+) -> (balance: Uint256) {
+    return ERC1155.balance_of(account, id);
+}
+
+// Batched version of balanceOf.
+// accounts_len and ids_len need to match
+@view
+func balanceOfBatch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*
+) -> (balances_len: felt, balances: Uint256*) {
+    return ERC1155.balance_of_batch(accounts_len, accounts, ids_len, ids);
+}
+
+// Returns true if operator is approved to transfer account's tokens.
+@view
+func isApprovedForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    account: felt, operator: felt
+) -> (approved: felt) {
+    return ERC1155.is_approved_for_all(account, operator);
+}
+
+@view
+func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+    return Ownable.owner();
+}
+
+//
+// Externals
+//
+
+// Grants or revokes permission to operator to transfer the caller’s tokens
+// disabled for SBT
+@external
+func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    operator: felt, approved: felt
+) {
+    with_attr error_message("SBT, no setApprovals") {
+        assert 1 = 0;
+    }
+    return ();
+}
+
+// Transfers amount tokens of token type id from from to to.
+// disabled for SBT
+@external
+func safeTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    with_attr error_message("SBT, no transfer") {
+        assert 0 = to;
+    }
+    return ();
+}
+
+// Batched version of safeTransferFrom.
+// disabled for SBT
+@external
+func safeBatchTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    with_attr error_message("SBT, no transfer") {
+        assert 0 = to;
+    }
+    return ();
+}
+
+// Creates amount new tokens for to, of token type id.
+// the caller must have the owner role
+@external
+func mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    Ownable.assert_only_owner();
+    ERC1155._mint(to, id, value, data_len, data);
+    return ();
+}
+
+// Batched variant of mint.
+@external
+func mintBatch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    Ownable.assert_only_owner();
+    ERC1155._mint_batch(to, ids_len, ids, values_len, values, data_len, data);
+    return ();
+}
+
+// Allows token holders to destroy/revoke their own tokens
+@external
+func burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, id: Uint256, value: Uint256
+) {
+    ERC1155.assert_owner_or_approved(owner=from_);
+    ERC1155._burn(from_, id, value);
+    return ();
+}
+
+@external
+func transferOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    newOwner: felt
+) {
+    Ownable.transfer_ownership(newOwner);
+    return ();
+}
+
+@external
+func renounceOwnership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    Ownable.renounce_ownership();
+    return ();
+}
+

--- a/src/contracts/sbt-ERC1155/src/SBT.cairo
+++ b/src/contracts/sbt-ERC1155/src/SBT.cairo
@@ -96,6 +96,7 @@ func setApprovalForAll{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 func safeTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
 ) {
+    ERC1155.assert_owner_or_approved(owner=from_);
     with_attr error_message("SBT, no transfer") {
         assert 0 = to;
     }
@@ -115,6 +116,7 @@ func safeBatchTransferFrom{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
     data_len: felt,
     data: felt*,
 ) {
+    ERC1155.assert_owner_or_approved(owner=from_);
     with_attr error_message("SBT, no transfer") {
         assert 0 = to;
     }

--- a/src/contracts/sbt-ERC1155/tests/test_token.cairo
+++ b/src/contracts/sbt-ERC1155/tests/test_token.cairo
@@ -8,12 +8,6 @@ from starkware.cairo.common.alloc import alloc
 
 from interfaces.ISBT import ISBT
 
-struct Contracts {
-    ADMIN: felt,
-    FREN: felt,
-    sbt_address: felt,
-}
-
 const URI = 'ipfs:/';
 
 const ADMIN_PK = 101;
@@ -118,6 +112,7 @@ func test_mint{syscall_ptr: felt*, range_check_ptr}(
         print("mint test successful")
     %}
 
+    // mint by unauthorized
     %{ expect_revert(error_message="Ownable: caller is not the owner") %}
     %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
     ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
@@ -178,6 +173,7 @@ func test_mint_batch{syscall_ptr: felt*, range_check_ptr}(
         print("mintBatch test successful")
     %}
 
+    // mintBatch by unauthorized
     %{ expect_revert(error_message="Ownable: caller is not the owner") %}
     %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
         ISBT.mintBatch(contract_address=sbt_address, to=fren, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
@@ -363,7 +359,7 @@ func test_batch_transfer{syscall_ptr: felt*, range_check_ptr}(
     ISBT.mintBatch(contract_address=sbt_address, to=fren, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
     %{ stop_prank() %}
 
-    // transfer
+    // batchTransfer
     %{ expect_revert(error_message="SBT, no transfer") %}
     %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
     ISBT.safeBatchTransferFrom(contract_address=sbt_address, from_=fren, to=admin, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);

--- a/src/contracts/sbt-ERC1155/tests/test_token.cairo
+++ b/src/contracts/sbt-ERC1155/tests/test_token.cairo
@@ -1,0 +1,376 @@
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.math import assert_not_equal
+from starkware.cairo.common.alloc import alloc
+
+from interfaces.ISBT import ISBT
+
+struct Contracts {
+    ADMIN: felt,
+    FREN: felt,
+    sbt_address: felt,
+}
+
+const URI = 'ipfs:/';
+
+const ADMIN_PK = 101;
+const FREN_PK = 201;
+
+@external 
+func __setup__() {
+    %{
+        context.admin = deploy_contract("./lib/cairo_contracts/src/openzeppelin/account/presets/Account.cairo", 
+            [ids.ADMIN_PK]
+        ).contract_address
+
+        context.fren = deploy_contract("./lib/cairo_contracts/src/openzeppelin/account/presets/Account.cairo", 
+            [ids.FREN_PK]
+        ).contract_address
+
+        context.uri = ids.URI
+        context.sbt_address = deploy_contract("./src/SBT.cairo", [context.uri, context.admin]).contract_address
+    %}
+    return ();
+}
+
+@external
+func test_deploy{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+
+    let (_uri) = ISBT.uri(sbt_address, Uint256(0,0));
+    assert URI = _uri;
+
+    let (owner) = ISBT.owner(sbt_address);
+    assert admin = owner;
+
+    // transferOwnership
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.transferOwnership(contract_address=sbt_address, newOwner=fren);
+    %{ stop_prank() %}
+
+    let (owner) = ISBT.owner(sbt_address);
+    assert fren = owner;
+
+    // renounceOwnership
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+    ISBT.renounceOwnership(contract_address=sbt_address);
+    %{ stop_prank() %}
+
+    let (owner) = ISBT.owner(sbt_address);
+    assert 0 = owner;
+
+    %{  
+        print("Deploy successful")
+        print(ids.URI)
+    %}
+    return();
+}
+
+@external
+func test_mint{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+
+    let (local data: felt*) = alloc();
+
+    // mint
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    // balanceOf
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    // isApprovedForAll
+    let (approved) = ISBT.isApprovedForAll(contract_address=sbt_address, account=fren, operator=admin);
+    assert 0 = approved;
+
+    %{
+        print("mint test successful")
+    %}
+
+    %{ expect_revert(error_message="Ownable: caller is not the owner") %}
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}
+
+@external
+func test_mint_batch{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+    let two_as_uint256: Uint256 = Uint256(2, 0);
+
+    let (local data: felt*) = alloc();
+
+    let (local ids: Uint256*) = alloc();
+    assert ids[0] = zero_as_uint256;
+    assert ids[1] = one_as_uint256;
+    assert ids[2] = two_as_uint256;
+
+    let(local values: Uint256*) = alloc();
+    assert values[0] = one_as_uint256;
+    assert values[1] = one_as_uint256;
+    assert values[2] = one_as_uint256;
+
+    // mintBatch
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mintBatch(contract_address=sbt_address, to=fren, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    // balanceOf
+    let (balance) = ISBT.balanceOf(sbt_address, fren, zero_as_uint256);
+    assert one_as_uint256 = balance;
+
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    let (balance) = ISBT.balanceOf(sbt_address, fren, two_as_uint256);
+    assert one_as_uint256 = balance;
+
+    %{
+        print("mintBatch test successful")
+    %}
+
+    %{ expect_revert(error_message="Ownable: caller is not the owner") %}
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+        ISBT.mintBatch(contract_address=sbt_address, to=fren, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}
+
+@external
+func test_burn{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+
+    let (local data: felt*) = alloc();
+
+    // mint
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+    // check
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    // burn
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+    ISBT.burn(contract_address=sbt_address, from_=fren, id=one_as_uint256, value=one_as_uint256);
+    %{ stop_prank() %}
+    // check
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert zero_as_uint256 = balance;
+
+    // mint again
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+    // check
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    %{
+        print("burn test successful")
+    %}
+
+    // burn 
+    %{ expect_revert(error_message="ERC1155: caller is not owner nor approved") %}
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.burn(contract_address=sbt_address, from_=fren, id=one_as_uint256, value=one_as_uint256);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}
+
+@external
+func test_transfer_by_user{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+
+    let (local data: felt*) = alloc();
+
+    // mint
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    // balanceOf
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    // transfer
+    %{ expect_revert(error_message="SBT, no transfer") %}
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+    ISBT.safeTransferFrom(contract_address=sbt_address, from_=fren, to=admin, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}
+
+@external
+func test_transfer_by_admin{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+
+    let (local data: felt*) = alloc();
+
+    // mint
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mint(contract_address=sbt_address, to=fren, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    // balanceOf
+    let (balance) = ISBT.balanceOf(sbt_address, fren, one_as_uint256);
+    assert one_as_uint256 = balance;
+
+    // transfer
+    %{ expect_revert(error_message="SBT, no transfer") %}
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.safeTransferFrom(contract_address=sbt_address, from_=fren, to=admin, id=one_as_uint256, value=one_as_uint256, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}
+
+@external
+func test_batch_transfer{syscall_ptr: felt*, range_check_ptr}(
+) {
+    alloc_locals;
+    local sbt_address;
+    local admin;
+    local fren;
+
+    %{
+        ids.admin = context.admin
+        ids.fren = context.fren
+        ids.sbt_address = context.sbt_address
+    %}
+
+    let one_as_uint256: Uint256 = Uint256(1, 0);
+    let zero_as_uint256: Uint256 = Uint256(0, 0);
+    let two_as_uint256: Uint256 = Uint256(2, 0);
+
+    let (local data: felt*) = alloc();
+
+    let (local ids: Uint256*) = alloc();
+    assert ids[0] = zero_as_uint256;
+    assert ids[1] = one_as_uint256;
+    assert ids[2] = two_as_uint256;
+
+    let(local values: Uint256*) = alloc();
+    assert values[0] = one_as_uint256;
+    assert values[1] = one_as_uint256;
+    assert values[2] = one_as_uint256;
+
+    // mintBatch
+    %{ stop_prank = start_prank(ids.admin, ids.sbt_address) %}
+    ISBT.mintBatch(contract_address=sbt_address, to=fren, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    // transfer
+    %{ expect_revert(error_message="SBT, no transfer") %}
+    %{ stop_prank = start_prank(ids.fren, ids.sbt_address) %}
+    ISBT.safeBatchTransferFrom(contract_address=sbt_address, from_=fren, to=admin, ids_len=3, ids=ids, values_len=3, values=values, data_len=0, data=data);
+    %{ stop_prank() %}
+
+    %{
+        print("expect revert: don't print this")
+    %}
+    return();
+}


### PR DESCRIPTION
I created an ERC1155 Soulbound token as requested in issues. It's an implementation of OpenZeppelin's ERC1155MintableBurnable.cairo 

safeTransferFrom and safeBatchTransferFrom functions are disabled. setApprovalForAll and burnBatch are removed. Built and tested with Protostar.

Let me know if something could be improved.